### PR TITLE
Fix: assign Negative confidence for Depth_Score below threshold (improve filtering)

### DIFF
--- a/tests/unit/test_confidence_assignment.py
+++ b/tests/unit/test_confidence_assignment.py
@@ -5,9 +5,6 @@
 Unit tests for confidence assignment functionality.
 Validates confidence levels based on depth scores and thresholds
 from vntyper/scripts/kestrel_config.json.
-
-# Mark all tests in this module as unit tests
-pytestmark = pytest.mark.unit
 """
 
 import json
@@ -17,112 +14,126 @@ import pandas as pd
 import pytest
 
 from vntyper.scripts.confidence_assignment import (
+    NEGATIVE_LABEL,
     calculate_depth_score_and_assign_confidence,
 )
+
+pytestmark = pytest.mark.unit
+
+# Fixed region depth used across tests to isolate Depth_Score effects.
+# Must be above var_active_region_threshold (200) to avoid triggering cond1's region check.
+_REGION_DEPTH = 10000
 
 
 @pytest.fixture(scope="session")
 def kestrel_config():
-    """
-    Loads the Kestrel configuration from vntyper/scripts/kestrel_config.json.
-    Must contain a top-level "confidence_assignment" key.
-
-    Example structure of kestrel_config.json:
-    {
-      "confidence_assignment": {
-        "depth_score_thresholds": { ... },
-        "alt_depth_thresholds": { ... },
-        "var_active_region_threshold": 5000,
-        "confidence_levels": { ... }
-      },
-      ...
-    }
-    """
-    # Adjust path if needed; we go two levels up from tests/unit to
-    # find vntyper/scripts/kestrel_config.json.
-    # (Alternatively, use an absolute path or a more direct approach.)
+    """Load the Kestrel configuration from vntyper/scripts/kestrel_config.json."""
     this_file = Path(__file__).resolve()
-    scripts_dir = this_file.parents[2] / "vntyper" / "scripts"  # go up 2 dirs
-    config_path = scripts_dir / "kestrel_config.json"
-
+    config_path = this_file.parents[2] / "vntyper" / "scripts" / "kestrel_config.json"
     if not config_path.exists():
         pytest.exit(f"kestrel_config.json not found at {config_path}", returncode=1)
-
     with config_path.open("r") as f:
-        raw_config = json.load(f)
-
-    # Return the entire dictionary. The confidence_assignment subdict
-    # is used by calculate_depth_score_and_assign_confidence internally.
-    # i.e., that function does kestrel_config["confidence_assignment"].
-    return raw_config
+        return json.load(f)
 
 
-def test_calculate_depth_score_empty_df(kestrel_config):
-    """
-    Test behavior when input DataFrame is empty.
-    """
-    df = pd.DataFrame()
-    out = calculate_depth_score_and_assign_confidence(df, kestrel_config)
-    assert out.empty, "Empty input should yield empty output."
-
-
-def test_calculate_depth_score_below_threshold_is_negative(kestrel_config):
-    """
-    Variants with Depth_Score below low_threshold get 'Negative' (filtered out), not Low_Precision.
-    """
-    # Depth 10/10000 = 0.001 < low (0.00469 in kestrel_config.json)
-    df = pd.DataFrame(
-        {
-            "Estimated_Depth_AlternateVariant": [10],
-            "Estimated_Depth_Variant_ActiveRegion": [10000],
-        }
-    )
-    out = calculate_depth_score_and_assign_confidence(df, kestrel_config)
-    assert out.loc[0, "Confidence"] == "Negative", (
-        "Depth_Score below low_threshold should be Negative (filtered out)."
-    )
-    assert not out.loc[0, "depth_confidence_pass"]
-
-
-def test_calculate_depth_score_low_precision(kestrel_config):
-    """
-    Variants with Depth_Score >= low_threshold but in low-precision band get 'Low_Precision'.
-    """
-    low = kestrel_config["confidence_assignment"]["depth_score_thresholds"]["low"]
-    high = kestrel_config["confidence_assignment"]["depth_score_thresholds"]["high"]
-    mid_low = kestrel_config["confidence_assignment"]["alt_depth_thresholds"]["mid_low"]
-    mid_high = kestrel_config["confidence_assignment"]["alt_depth_thresholds"]["mid_high"]
-    # Depth_Score in (low, high) and alt in [mid_low, mid_high] => Low_Precision (cond3)
-    depth_score = (low + high) / 2
-    alt_depth = (mid_low + mid_high) // 2
-    region_depth = int(alt_depth / depth_score) + 1
-    df = pd.DataFrame(
+def _make_df(alt_depth: float, region_depth: float = _REGION_DEPTH) -> pd.DataFrame:
+    """Helper to create a single-row DataFrame with the required depth columns."""
+    return pd.DataFrame(
         {
             "Estimated_Depth_AlternateVariant": [alt_depth],
             "Estimated_Depth_Variant_ActiveRegion": [region_depth],
         }
     )
+
+
+def test_calculate_depth_score_empty_df(kestrel_config):
+    """Empty input should yield empty output."""
+    df = pd.DataFrame()
     out = calculate_depth_score_and_assign_confidence(df, kestrel_config)
-    low_label = kestrel_config["confidence_assignment"]["confidence_levels"]["low_precision"]
-    assert out.loc[0, "Confidence"] == low_label, (
-        "Depth_Score in (low, high) with mid alt depth should be Low_Precision."
+    assert out.empty
+
+
+def test_depth_score_below_threshold_is_negative(kestrel_config):
+    """Variants with Depth_Score < low_threshold get Negative (filtered out)."""
+    low = kestrel_config["confidence_assignment"]["depth_score_thresholds"]["low"]
+    # Derive alt_depth that produces Depth_Score just below low_threshold
+    alt_depth = low * _REGION_DEPTH * 0.5  # half the threshold
+    out = calculate_depth_score_and_assign_confidence(_make_df(alt_depth), kestrel_config)
+    assert out.loc[0, "Confidence"] == NEGATIVE_LABEL
+    assert not out.loc[0, "depth_confidence_pass"]
+
+
+def test_depth_score_at_threshold_boundary_not_negative(kestrel_config):
+    """Variants with Depth_Score == low_threshold should NOT be Negative."""
+    low = kestrel_config["confidence_assignment"]["depth_score_thresholds"]["low"]
+    # Derive alt_depth that produces Depth_Score exactly at low_threshold
+    alt_depth = low * _REGION_DEPTH
+    out = calculate_depth_score_and_assign_confidence(_make_df(alt_depth), kestrel_config)
+    assert out.loc[0, "Confidence"] != NEGATIVE_LABEL, (
+        "Depth_Score at exactly low_threshold must not be Negative; "
+        "the Negative filter applies only to strictly lower scores."
     )
+    assert out.loc[0, "depth_confidence_pass"]
 
 
-def test_calculate_depth_score_high_precision(kestrel_config):
-    df = pd.DataFrame(
-        {
-            "Estimated_Depth_AlternateVariant": [100],
-            "Estimated_Depth_Variant_ActiveRegion": [5000],
-        }
-    )
-    out = calculate_depth_score_and_assign_confidence(df, kestrel_config)
+def test_depth_score_in_low_precision_band(kestrel_config):
+    """Variants with Depth_Score in (low, high) band get Low_Precision."""
+    conf = kestrel_config["confidence_assignment"]
+    low = conf["depth_score_thresholds"]["low"]
+    high = conf["depth_score_thresholds"]["high"]
+    mid_low = conf["alt_depth_thresholds"]["mid_low"]
+    mid_high = conf["alt_depth_thresholds"]["mid_high"]
+    low_label = conf["confidence_levels"]["low_precision"]
 
-    # If your function returns "High_Precision*",
-    # then let's just confirm the actual returned value is "High_Precision*".
-    high_star_label = kestrel_config["confidence_assignment"]["confidence_levels"][
-        "high_precision_star"
-    ]
-    assert (
-        out.loc[0, "Confidence"] == high_star_label
-    ), "Expected 'High_Precision*' for depth_score=0.02 with alt=100 >= mid_high=100"
+    # Target Depth_Score in (low, high) and alt in [mid_low, mid_high] => cond3 Low_Precision
+    depth_score = (low + high) / 2
+    alt_depth = (mid_low + mid_high) // 2
+    region_depth = int(alt_depth / depth_score) + 1
+
+    out = calculate_depth_score_and_assign_confidence(_make_df(alt_depth, region_depth), kestrel_config)
+    assert out.loc[0, "Confidence"] == low_label
+
+
+def test_depth_score_high_precision_star(kestrel_config):
+    """High alt depth + high Depth_Score => High_Precision*."""
+    conf = kestrel_config["confidence_assignment"]
+    high = conf["depth_score_thresholds"]["high"]
+    alt_mid_high = conf["alt_depth_thresholds"]["mid_high"]
+    high_star_label = conf["confidence_levels"]["high_precision_star"]
+
+    # alt >= mid_high AND Depth_Score >= high_threshold => cond2
+    alt_depth = alt_mid_high
+    region_depth = int(alt_depth / high)  # produces Depth_Score >= high
+
+    out = calculate_depth_score_and_assign_confidence(_make_df(alt_depth, region_depth), kestrel_config)
+    assert out.loc[0, "Confidence"] == high_star_label
+
+
+def test_low_region_depth_with_sufficient_depth_score(kestrel_config):
+    """Low region depth (below var_active_region_threshold) should get Low_Precision, not Negative."""
+    conf = kestrel_config["confidence_assignment"]
+    low = conf["depth_score_thresholds"]["low"]
+    var_region_threshold = conf["var_active_region_threshold"]
+    low_label = conf["confidence_levels"]["low_precision"]
+
+    # Region depth at threshold, but Depth_Score above low_threshold
+    region_depth = var_region_threshold
+    alt_depth = low * region_depth * 2  # Depth_Score = 2 * low_threshold (well above)
+
+    out = calculate_depth_score_and_assign_confidence(_make_df(alt_depth, region_depth), kestrel_config)
+    assert out.loc[0, "Confidence"] == low_label
+
+
+def test_low_region_depth_with_insufficient_depth_score(kestrel_config):
+    """Low region depth AND Depth_Score below threshold should still be Negative."""
+    conf = kestrel_config["confidence_assignment"]
+    low = conf["depth_score_thresholds"]["low"]
+    var_region_threshold = conf["var_active_region_threshold"]
+
+    # Both below thresholds
+    region_depth = var_region_threshold
+    alt_depth = low * region_depth * 0.5  # Depth_Score = 0.5 * low_threshold
+
+    out = calculate_depth_score_and_assign_confidence(_make_df(alt_depth, region_depth), kestrel_config)
+    assert out.loc[0, "Confidence"] == NEGATIVE_LABEL
+    assert not out.loc[0, "depth_confidence_pass"]

--- a/vntyper/scripts/confidence_assignment.py
+++ b/vntyper/scripts/confidence_assignment.py
@@ -25,8 +25,12 @@ References:
 
 import logging
 
-import numpy as np  # Import NumPy directly
+import numpy as np
 import pandas as pd
+
+# Confidence label for variants that fail depth-based filtering.
+# Used as the default and for Depth_Score below the configured low_threshold.
+NEGATIVE_LABEL = "Negative"
 
 
 def calculate_depth_score_and_assign_confidence(df: pd.DataFrame, kestrel_config: dict) -> pd.DataFrame:
@@ -105,11 +109,17 @@ def calculate_depth_score_and_assign_confidence(df: pd.DataFrame, kestrel_config
     df["Depth_Score"] = df["Depth_Score"].replace([np.inf, -np.inf], np.nan)
 
     # Step 3: Assign Confidence
-    # Default all rows to 'Negative', then update based on conditions.
-    df["Confidence"] = "Negative"
+    # Default all rows to NEGATIVE_LABEL, then upgrade based on conditions.
+    # Variants with Depth_Score < low_threshold remain Negative (filtered out).
+    df["Confidence"] = NEGATIVE_LABEL
 
-    # Condition 1: Low Precision if Depth_Score <= low_threshold OR region depth <= var_region_threshold
-    cond1 = (df["Depth_Score"] <= low_threshold) | (df["Estimated_Depth_Variant_ActiveRegion"] <= var_region_threshold)
+    # Guard: only variants at or above the minimum depth threshold can receive
+    # a non-Negative confidence label. This ensures all variants (GG and non-GG)
+    # with insufficient depth are excluded from downstream analysis (fixes #147).
+    above_min_threshold = df["Depth_Score"] >= low_threshold
+
+    # Condition 1: Low Precision if Depth_Score == low_threshold OR region depth <= var_region_threshold
+    cond1 = (df["Depth_Score"] == low_threshold) | (df["Estimated_Depth_Variant_ActiveRegion"] <= var_region_threshold)
 
     # Condition 2: High Precision STAR if alt depth >= alt_mid_high AND Depth_Score >= high_threshold
     cond2 = (df["Estimated_Depth_AlternateVariant"] >= alt_mid_high) & (df["Depth_Score"] >= high_threshold)
@@ -129,24 +139,19 @@ def calculate_depth_score_and_assign_confidence(df: pd.DataFrame, kestrel_config
     )
 
     # Condition 6: Catch-all - Low Precision if Depth_Score is between low_threshold and high_threshold (exclusive)
-    # Note: Redundant (df["Confidence"] == "Negative") check removed per Copilot review (PR #140)
-    # All conditions are evaluated BEFORE application, so all rows start as "Negative"
     cond6 = (df["Depth_Score"] > low_threshold) & (df["Depth_Score"] < high_threshold)
 
-    # Apply conditions in order (later conditions can overwrite earlier ones)
-    df.loc[cond1, "Confidence"] = low_prec_label
-    df.loc[cond2, "Confidence"] = high_prec_star_label
-    df.loc[cond3, "Confidence"] = low_prec_label
-    df.loc[cond4, "Confidence"] = low_prec_label
-    df.loc[cond5, "Confidence"] = high_prec_label
-    df.loc[cond6, "Confidence"] = low_prec_label
+    # Apply conditions in order (later conditions can overwrite earlier ones).
+    # The above_min_threshold guard ensures Depth_Score < low_threshold stays Negative.
+    df.loc[cond1 & above_min_threshold, "Confidence"] = low_prec_label
+    df.loc[cond2 & above_min_threshold, "Confidence"] = high_prec_star_label
+    df.loc[cond3 & above_min_threshold, "Confidence"] = low_prec_label
+    df.loc[cond4 & above_min_threshold, "Confidence"] = low_prec_label
+    df.loc[cond5 & above_min_threshold, "Confidence"] = high_prec_label
+    df.loc[cond6 & above_min_threshold, "Confidence"] = low_prec_label
 
-    # Override: Depth_Score below low_threshold => Negative (filtered out), not Low_Precision.
-    # Ensures all variants (GG and non-GG) with insufficient depth are excluded.
-    df.loc[df["Depth_Score"] < low_threshold, "Confidence"] = "Negative"
-
-    # Step 4: Mark pass/fail: Passing means Confidence != 'Negative'
-    df["depth_confidence_pass"] = df["Confidence"] != "Negative"
+    # Step 4: Mark pass/fail: Passing means Confidence != NEGATIVE_LABEL
+    df["depth_confidence_pass"] = df["Confidence"] != NEGATIVE_LABEL
 
     logging.debug("Exiting calculate_depth_score_and_assign_confidence")
     logging.debug(f"Final DataFrame shape: {df.shape}")


### PR DESCRIPTION
**Summary**
Variants with Depth_Score below the configured low_threshold (e.g. 0.00469 in kestrel_config.json) were previously assigned Low_Precision and passed filtering. Only GG variants were filtered by depth via alt_filter_pass; non-GG variants with low depth scores were not excluded.

This change fixes variant filtering so that all variants (GG and non-GG) with Depth_Score < low_threshold are assigned Negative confidence and are filtered out.

**Changes**
`vntyper/scripts/confidence_assignment.py`

In calculate_depth_score_and_assign_confidence(), after applying existing confidence conditions, add an override: set Confidence = "Negative" for any row where Depth_Score < low_threshold.
depth_confidence_pass remains True only when Confidence != "Negative", so these variants are now correctly excluded by downstream logic.
Docstring updated to describe this behaviour.

`tests/unit/test_confidence_assignment.py`
New test test_calculate_depth_score_below_threshold_is_negative: asserts that Depth_Score below low_threshold yields Confidence == "Negative" and depth_confidence_pass == False.
test_calculate_depth_score_low_precision updated to use a case with Depth_Score in the (low, high) band so the Low_Precision band is still covered.

**Result**
Variants with Depth_Score below the configured threshold are now consistently filtered out regardless of ALT type.

This will fix #147

## Summary by Sourcery

Enforce negative confidence for variants with depth scores below the configured low threshold and adjust tests to cover the updated depth-based confidence behaviour.

Bug Fixes:
- Assign negative confidence to all variants whose Depth_Score is below the configured low_threshold so they are consistently filtered out.

Tests:
- Add and update unit tests to verify that variants below the depth threshold are marked negative and that low-precision cases in the valid band still receive Low_Precision confidence.