### PR TITLE
test(issue-156): add GDP inflation guard test

### DIFF
--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -111,6 +111,17 @@ def ensure_test_data(test_config):
             download_file(archive_url, tmp_path)
             logger.info("Archive downloaded to %s", tmp_path)
 
+            # Verify archive MD5 if configured
+            expected_archive_md5 = archive_config.get("md5sum")
+            if expected_archive_md5:
+                actual_archive_md5 = compute_md5(tmp_path)
+                if actual_archive_md5.lower() != expected_archive_md5.lower():
+                    pytest.exit(
+                        f"Archive MD5 mismatch.\nExpected={expected_archive_md5}, Got={actual_archive_md5}",
+                        returncode=1,
+                    )
+                logger.info("Archive MD5 verified: %s", actual_archive_md5)
+
             # Extract archive
             logger.info("Extracting archive to %s", extract_to)
             extract_to.mkdir(parents=True, exist_ok=True)

--- a/tests/test_data_config.json
+++ b/tests/test_data_config.json
@@ -671,6 +671,18 @@
       "filename": "example_dfc3_hg38_ensembl_bwa.bam.bai",
       "url_suffix": "",
       "md5sum": "10d1fcd3169c810cad2b941d34471d32"
+    },
+    {
+      "local_path": "tests/data",
+      "filename": "example_40cf_hg38_subset.bam",
+      "url_suffix": "",
+      "md5sum": "ca4a47b964530ea65c1a72daa36bfaa4"
+    },
+    {
+      "local_path": "tests/data",
+      "filename": "example_40cf_hg38_subset.bam.bai",
+      "url_suffix": "",
+      "md5sum": "bb1596845be1daeb4d79c989ea7ba4fc"
     }
   ],
   "archive_file": {
@@ -889,6 +901,28 @@
             "tolerance_percentage": 5
           },
           "Confidence": "High_Precision*"
+        },
+        "check_igv_report": false
+      },
+      {
+        "test_name": "example_40cf_hg38_subset_fast_gdp_guard",
+        "description": "Guard against GDP inflation (Issue #156): this sample was falsely positive with maxhapstates/maxalignstates > 50 due to motif-specific ALT support inflation. With maxhapstates/maxalignstates=40 it must be Negative.",
+        "bam": "tests/data/example_40cf_hg38_subset.bam",
+        "reference_assembly": "hg38",
+        "cli_options": [
+          "--fast-mode",
+          "--keep-intermediates",
+          "--archive-results"
+        ],
+        "expected_archive": true,
+        "kestrel_assertions": {
+          "Estimated_Depth_AlternateVariant": "None",
+          "Estimated_Depth_Variant_ActiveRegion": "None",
+          "Depth_Score": {
+            "value": "None",
+            "tolerance_percentage": 5
+          },
+          "Confidence": "Negative"
         },
         "check_igv_report": false
       }

--- a/tests/test_data_config.json
+++ b/tests/test_data_config.json
@@ -687,9 +687,9 @@
   ],
   "archive_file": {
     "filename": "data.zip",
-    "url": "https://zenodo.org/records/17479292/files/data.zip?download=1",
+    "url": "https://zenodo.org/records/19181821/files/data.zip?download=1",
     "extract_to": "tests/data",
-    "md5sum": null
+    "md5sum": "fdd5958d58c733cdca452f3287898964"
   },
   "unit_tests": {},
   "integration_tests": {


### PR DESCRIPTION
## Summary
- Anonymized BAM sample (`example_40cf_hg38_subset`) added as regression guard for Issue #156 (GDP inflation with `maxhapstates/maxalignstates > 50`)
- This sample was falsely positive with v2.0.2 parameters but must be **Negative** with current `maxhapstates/maxalignstates=40`
- Updated Zenodo test data archive to v4.0.0 (`10.5281/zenodo.19181821`) with new sample included
- Updated `test_data_config.json` with new file resources, test case, and Zenodo URL

## Anonymization
- BAM anonymized using `reference/pseudonymize.py` — all identifying info removed (headers, RG tags, PG lines with file paths/URLs, CO lines)
- Pseudonym: `example_40cf`
- No patient-identifying strings remain (verified)

## Test plan
- [x] Integration test passes: `example_40cf_hg38_subset_fast_gdp_guard` → Negative confidence
- [x] Zenodo v4.0.0 published and downloadable
- [x] All unit tests pass (278 passed)
- [x] Lint, format, type-check all pass
- [x] No references to old Zenodo record remaining

Closes #156

## Summary by Sourcery

Add a regression guard test and supporting test data for the GDP inflation issue when maxhapstates/maxalignstates are limited to 40.

New Features:
- Introduce an anonymized BAM-based integration test case to ensure GDP calls remain negative under the current maxhapstates/maxalignstates settings.

Enhancements:
- Update test data configuration and Zenodo test data archive reference to include the new anonymized sample and ensure tests use the latest dataset version.