### PR TITLE
Fix/report summary (#167)

### DIFF
--- a/vntyper/cli.py
+++ b/vntyper/cli.py
@@ -619,9 +619,6 @@ def main():
             bam_file=args.bam_file,
             fasta_file=args.reference_fasta,
             flanking=args.flanking,
-            input_files={},  # Optionally populate if you want to reference them in the final report
-            pipeline_version=VERSION,
-            mean_vntr_coverage=None,  # If applicable, otherwise remove
             vcf_file=None,  # If applicable, otherwise remove
             config=config,
         )

--- a/vntyper/cli.py
+++ b/vntyper/cli.py
@@ -205,6 +205,7 @@ def main():
     parser_report.add_argument("--report-file", type=str, default=None, help="Name of the output report file.")
     parser_report.add_argument("--bed-file", type=Path, help="Path to the BED file for IGV reports.")
     parser_report.add_argument("--bam-file", type=Path, help="Path to the BAM file for IGV reports.")
+    parser_report.add_argument("--vcf-file", type=Path, help="Path to the VCF file for IGV reports.")
     parser_report.add_argument(
         "--reference-fasta",
         type=Path,
@@ -610,6 +611,13 @@ def main():
                 args.bed_file = candidate_bed
                 logging.debug(f"bed_file set to {args.bed_file}")
 
+        # Same approach for vcf-file (standard name is "output_indel.vcf" in "kestrel")
+        if args.vcf_file is None and args.input_dir:
+            candidate_vcf = args.input_dir / "kestrel" / "output_indel.vcf"
+            if candidate_vcf.exists():
+                args.vcf_file = candidate_vcf
+                logging.debug(f"vcf_file set to {args.vcf_file}")
+
         # Now call generate_summary_report
         generate_summary_report(
             output_dir=Path(args.output_dir),
@@ -619,7 +627,7 @@ def main():
             bam_file=args.bam_file,
             fasta_file=args.reference_fasta,
             flanking=args.flanking,
-            vcf_file=None,  # If applicable, otherwise remove
+            vcf_file=args.vcf_file,
             config=config,
         )
 

--- a/vntyper/scripts/generate_report.py
+++ b/vntyper/scripts/generate_report.py
@@ -418,7 +418,6 @@ def generate_summary_report(
     output_dir,
     template_dir,
     report_file,
-    log_file,
     bed_file=None,
     bam_file=None,
     fasta_file=None,
@@ -438,7 +437,6 @@ def generate_summary_report(
         output_dir (str): Output directory for the report.
         template_dir (str): Directory containing the report template.
         report_file (str): Name of the report file.
-        log_file (str): Path to the pipeline log file.
         bed_file (str, optional): Path to the BED file for IGV reports.
         bam_file (str, optional): Path to the BAM file for IGV reports.
         fasta_file (str, optional): Path to the reference FASTA file for IGV reports.
@@ -456,6 +454,7 @@ def generate_summary_report(
         template_dir,
         report_file,
     )
+    log_file = Path(output_dir) / "pipeline.log"
     logging.debug(
         "bed_file=%s, bam_file=%s, fasta_file=%s, flanking=%s, log_file=%s, vcf_file=%s",
         bed_file,


### PR DESCRIPTION
## Changes

- removed input_files, pipeline_version and mean_vntr_coverage from function call as they are extracted inside the function
- removed log_file argument as it can be created inside the function starting from output_dir
- added --vcf-file argument to the parser if the user wants to define a vcf, otherwise if --input-dir is provided it will look in the kestrel folder as it is done for bed and bam files.

## Summary by Sourcery

Update summary report generation to rely on internally derived context and support optional VCF input resolution.

New Features:
- Add an optional --vcf-file CLI argument for providing a VCF file to the report generator, with automatic discovery from the kestrel directory when not supplied.

Enhancements:
- Simplify generate_summary_report API by removing now-redundant parameters that are derived internally.
- Derive the pipeline log file path from the output directory inside generate_summary_report instead of passing it as an argument.