### PR TITLE
Add AGENTS.md for coding agents and fix .gitignore shadowing docs/

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(make lint)",
+      "Bash(make lint-stats)",
+      "Bash(make format)",
+      "Bash(make format-check)",
+      "Bash(make type-check)",
+      "Bash(make type-check-tests)",
+      "Bash(make type-check-all)",
+      "Bash(make test-unit)",
+      "Bash(make test-quiet)",
+      "Bash(make check-all)",
+      "Bash(make docs-build)",
+      "Bash(make help)",
+      "Bash(ruff check:*)",
+      "Bash(ruff format:*)",
+      "Bash(pytest -m unit:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git check-ignore:*)"
+    ],
+    "deny": [
+      "Bash(git push --tags:*)",
+      "Bash(git tag:*)",
+      "Bash(twine upload:*)",
+      "Read(./tests/data/**)",
+      "Read(./reference/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
+# NOTE: do NOT ignore docs/ itself - it holds the tracked MkDocs site sources.
 docs/_build/
-docs/
 
 # PyBuilder
 .pybuilder/
@@ -192,15 +192,23 @@ fastp.json
 /docker/test_output/
 /testing/
 
-# Local Dockerfile (for local development/testing)
-Dockerfile
+# Local Dockerfile at the repo root (for local development/testing).
+# Anchored so that the tracked docker/Dockerfile is never ignored.
+/Dockerfile
 
 # apptainer files
 *.sif
 
-# claude files and folders
-.claude/
-CLAUDE.md
+# coding-agent configuration
+# AGENTS.md, CLAUDE.md and .claude/settings.json are tracked on purpose - they are
+# shared project instructions. Only per-developer overrides stay local.
+.claude/settings.local.json
+.claude/state/
+.claude/*.local.json
+.mcp.local.json
+
+# local clone of the upstream adVNTR source tree (installed, not vendored)
+/adVNTR/
 
 # local development documentation and sensitive configs
 plan/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# AGENTS.md
+
+Instructions for coding agents working in this repository. Human contributors should
+read [CONTRIBUTING.md](CONTRIBUTING.md); everything below is the agent-facing summary
+plus the repo-specific traps that are easy to get wrong.
+
+## Project
+
+VNtyper genotypes the MUC1 coding VNTR to diagnose ADTKD-MUC1 from short-read data
+(BAM/CRAM/FASTQ). It runs mapping-free k-mer genotyping (Kestrel, vendored JAR),
+optionally validates with adVNTR, and emits confidence-scored calls plus an HTML report.
+
+Python package `vntyper`, one console entry point: `vntyper`. Version lives only in
+`vntyper/version.py`. Research use only — clinical-sounding output text is
+config-driven, never invent or reword it.
+
+## Setup
+
+The pipeline needs external binaries (bwa, samtools, fastp, bcftools, Java 11), so
+`pip install` alone does **not** give you a working pipeline:
+
+```bash
+mamba env create -f conda/environment_vntyper.yml   # env name: vntyper
+conda activate vntyper
+make install-dev                                    # pip install -e .[dev]
+```
+
+`CONTRIBUTING.md` still references a root `environment.yml` and a `vntyper-dev` env.
+Neither exists — use the commands above.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Full pre-PR gate | `make check-all` |
+| Format + autofix | `make format` |
+| Lint | `make lint` |
+| Type check | `make type-check` |
+| Fast tests (what CI runs) | `make test-unit` |
+| Integration tests | `make test-integration` |
+| Coverage | `make test-cov` |
+| Docs preview | `make docs-serve` |
+| Docs build (CI-equivalent) | `make docs-build` |
+
+Always run `make check-all` before opening a PR. Run pytest **from the repo root** —
+`tests/parametrization.py` opens `tests/test_data_config.json` by relative path at
+collection time, so any other CWD breaks collection, including `-m unit`.
+
+## Layout
+
+- `vntyper/cli.py` — argparse CLI; subcommands `pipeline`, `report`, `cohort`,
+  `install-references`, `online`. Sole place logging is configured.
+- `vntyper/scripts/pipeline.py` — `run_pipeline()`, orchestrates every stage.
+- `vntyper/scripts/` — stage modules: `fastq_bam_processing`, `alignment_processing`,
+  `kestrel_genotyping`, `variant_parsing`, `scoring`, `confidence_assignment`,
+  `motif_processing`, `flagging`, `summary`, `cross_match`, `generate_report`,
+  `cohort_summary`, `reference_registry`, `region_utils`, `chromosome_utils`.
+- `vntyper/modules/{advntr,shark}/` — optional `--extra-modules` stages.
+- `docker/app/` — the FastAPI + Celery web service. It is *not* part of the `vntyper`
+  package and is not covered by `make lint` / `make type-check`.
+- `vntyper/dependencies/kestrel/` — vendored JARs, never hand-edit.
+
+## Code style
+
+- Ruff is the only formatter and linter. **Line length 120**, double quotes,
+  `target-version = "py39"`. Do not reformat to black's 88.
+- Code must run on Python 3.9 (CI matrix: 3.9–3.12). Your local interpreter is newer,
+  so 3.10+ syntax can pass locally and break CI.
+- Google-style docstrings (`Args:` / `Returns:` / `Raises:`) on public functions.
+- Logging: modules call `logging.info(...)` on the root logger; configuration happens
+  once in `cli.py`. Do not add `basicConfig` or per-module handlers.
+- Errors: no custom exception classes. The convention is `logging.error(msg)` followed
+  by `raise ValueError(msg)` / `RuntimeError(msg)` with the same message. Only exit
+  codes 0 and 1 are used.
+- Type hints are partial. Newer modules (`reference_registry`, `region_utils`,
+  `scoring`, `flagging`) are fully annotated — match that when editing them.
+
+## Testing
+
+- `pytest.ini` at the repo root is the live config. The `[tool.pytest.ini_options]`
+  block in `pyproject.toml` is **dead** — pytest.ini takes precedence. Edit `pytest.ini`.
+- Markers: `unit`, `integration`, `docker`, `slow`.
+- **Every new unit test file must declare `pytestmark = pytest.mark.unit`.** CI runs
+  `pytest -m unit`, so an unmarked file silently never runs.
+  (`tests/unit/test_haplo_count_and_selection.py` is currently unmarked — 30 tests
+  invisible to CI.)
+- Unit tests must stay pure: `tmp_path` + `unittest.mock`, no network, no reference data.
+- Integration and docker tests pull a ~1.1 GB Zenodo archive and MD5 all 114 files; one
+  missing file triggers a full re-download. There are **no** `pytest.skip` guards
+  anywhere — missing data calls `pytest.exit()` and kills the whole session, unit tests
+  included. Set `VNTYPER_TEST_DATA_SKIP_DOWNLOAD=1` to fail fast instead of downloading.
+- Correct marker composition is `-m "docker and not slow"`; repeated `-m` flags override
+  rather than combine.
+
+## Git and PRs
+
+- Branch from `main` (there is no `develop` despite the CI trigger list). Observed
+  naming: `fix/issue-145-flagging-before-selection`, `test/issue-156-gdp-inflation-guard`,
+  `docs/mkdocs-site`. Use `<type>/issue-<N>-<slug>` or `<type>/<slug>`.
+- Conventional Commits: `type(scope): lowercase subject` under ~72 chars, with
+  `Closes #N` in the footer. Scopes are module or area names (`kestrel`, `flagging`,
+  `config`, `ci`, `docker`).
+- PRs are **not** squashed — every commit becomes permanent history. Keep them clean.
+- Copilot and Sourcery AI review PRs. The established pattern is a follow-up commit
+  addressing their comments, not a force-push.
+- CI gates on PRs: `make lint`, `make type-check`, `make test-unit` across 3.9–3.12,
+  plus a Docker image build and quick Docker tests. Formatting is *not* gated in CI —
+  run `make format-check` yourself.
+
+## Traps
+
+1. **Config is loaded at import time.** `kestrel_genotyping.py`, `advntr_genotyping.py`
+   and `shark_filtering.py` read their JSON into module globals on import, and
+   `run_kestrel()` uses `global kestrel_config` rather than its `config` argument.
+   `--config-path` cannot override them; tests must patch the module global.
+2. **`--config-path` replaces the whole config, it does not merge.** Missing keys raise
+   `KeyError` deep in the pipeline (`config["tools"]["java_path"]`, no `.get`).
+3. **Rule strings are `eval()`d against DataFrame column names.** `flagging.py` and
+   `cross_match.py` evaluate expressions from `kestrel_config.json`,
+   `advntr_config.json` and `config.json`. Renaming a column silently turns flags off —
+   a `NameError` only logs a warning. Grep the JSON configs before renaming any column.
+4. **Stages mark, they do not filter.** Kestrel stages append boolean columns
+   (`is_frameshift`, `is_valid_frameshift`, `depth_confidence_pass`, `alt_filter_pass`,
+   `motif_filter_pass`); `filter_final_dataframe()` ANDs them at the end. Preserve that
+   contract — dropping rows early breaks `kestrel_pre_result.tsv` debuggability.
+5. **Summary step names are string literals.** `"Kestrel Genotyping"`,
+   `"adVNTR Genotyping"`, `"Coverage Calculation"`, `"BAM Header Parsing"`,
+   `"Cross-Match Variant Comparison"` are matched exactly by `generate_report.py`,
+   `cohort_summary.py` and `cross_match.py`. All `parsed_result` values are strings.
+6. **Conda env names are load-bearing.** `config.json` shells out to
+   `mamba run -n envadvntr advntr` and `mamba run -n shark_env shark`. `envadvntr` is
+   Python 2.7 and can never be merged into the main env.
+7. **All tool and reference paths in `config.json` are relative to the process CWD.**
+   `pipeline.py` pins `project_root = os.getcwd()` and threads it as `cwd=` into Java
+   and samtools calls — do not remove that plumbing.
+8. **Kestrel is pinned to 1.0.1.** Scoring thresholds are calibrated to it; 1.0.2 output
+   differs. Do not upgrade the JAR.
+9. **`run_command` uses `shell=True`** deliberately, for process substitution in the CRAM
+   unmapped-read path. Converting it to `shell=False` breaks that branch.
+10. **The Docker build clones from GitHub**, it does not build your local checkout. Only
+    `docker/entrypoint.sh` and `docker/app/` come from the local context.
+11. **`vntyper report` is currently broken** — `cli.py` passes arguments
+    `generate_summary_report()` does not accept. Do not copy that call site as an example.
+12. **Version lives in three places**: `vntyper/version.py` (authoritative),
+    `CITATION.cff`, and `docs/about/changelog.md` (currently stale at 2.0.1).
+
+## Never
+
+- Never push a `v*.*.*` tag. It publishes to PyPI immediately and irreversibly.
+- Never commit into `tests/data/`, `reference/`, `out/`, `download/`, `vntyper.egg-info/`
+  or the local `adVNTR/` clone — all are generated or downloaded.
+- Never hand-edit `vntyper/dependencies/kestrel/*.jar` or anything in `vntyper.egg-info/`.
+- Never add a page under `docs/` without registering it in `mkdocs.yml` `nav:` —
+  the docs workflow runs `mkdocs build --strict`, so a dangling nav entry or broken
+  internal link fails CI.
+- Never claim tests pass without showing the command output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+Project instructions for this repository live in **[AGENTS.md](AGENTS.md)**. Read it
+before making any change — it is the single source of truth for setup, commands, code
+style, testing, git conventions, and the repo-specific traps.
+
+This file exists only so Claude Code picks the instructions up automatically. Keep it a
+pointer: add new guidance to `AGENTS.md`, not here.
+
+Quick reference:
+
+- Verify with `make check-all` before proposing a PR.
+- Fast feedback loop: `make format && make test-unit`, run from the repo root.
+- The pipeline needs the `vntyper` conda env; `pip install -e .[dev]` alone is not enough.


### PR DESCRIPTION
## Summary

Sets the repo up for agentic development and fixes a `.gitignore` rule that was
silently hiding new documentation pages.

## The `.gitignore` bug

`docs/` was ignored (line 73, a leftover from the Sphinx block of the Python
gitignore template) even though the 39 MkDocs source files under `docs/` are
tracked. Tracked files were unaffected, but **any newly created page was invisible
to `git add` and `git status`**:

```
$ git check-ignore -v docs/new.md
.gitignore:73:docs/	docs/new.md
```

Since `.github/workflows/docs.yml` runs `mkdocs build --strict`, adding a page,
registering it in `mkdocs.yml` `nav:`, and forgetting `git add -f` produces a
green local build and a red CI run. Only `docs/_build/` is kept now.

Same pass:

- `Dockerfile` → `/Dockerfile`, so the local-dev rule cannot shadow `docker/Dockerfile`.
- Track shared agent config (`AGENTS.md`, `CLAUDE.md`, `.claude/settings.json`);
  ignore only per-developer overrides (`.claude/settings.local.json`, `.mcp.local.json`).
- Ignore the local `adVNTR/` upstream clone, previously untracked noise in every `git status`.

## AGENTS.md

Follows the [agents.md](https://agents.md) convention — one file at the repo root,
read by Claude Code, Codex, Cursor, Gemini CLI and others. Content is derived from a
review of the build tooling, test setup, package architecture and contribution
history rather than restating the README. It covers setup, the canonical `make`
targets, repo layout, code style, testing rules, git/PR conventions, and the traps
that are genuinely easy to get wrong:

- config JSON loaded into module globals at **import** time, so `--config-path`
  cannot override it and tests must patch the module global
- flagging and cross-match rules are `eval()`d strings referencing DataFrame column
  names — renaming a column turns flags off with only a warning
- Kestrel stages **mark, they don't filter** (`is_frameshift`, `alt_filter_pass`, …)
- conda env names `envadvntr` / `shark_env` are load-bearing in `config.json`
- tool and reference paths are CWD-relative; `project_root` plumbing must stay
- Kestrel pinned to 1.0.1 (scoring is calibrated to it)
- pushing a `v*.*.*` tag publishes to PyPI immediately

`CLAUDE.md` is deliberately a 5-line pointer so guidance lives in one place.

`.claude/settings.json` pre-approves the read-only and verification commands agents
run constantly (`make lint`, `make test-unit`, `git diff`, …) and denies `git tag`
and `twine upload`.

## Verification

```
$ VNTYPER_TEST_DATA_SKIP_DOWNLOAD=1 pytest -m unit -q --ignore=tests/docker --ignore=tests/integration
278 passed, 30 deselected, 2 warnings in 0.45s

$ git check-ignore -v docs/new.md        # (no match — fixed)
$ git check-ignore -v docker/Dockerfile  # (no match — still safe)
$ git check-ignore -v Dockerfile
.gitignore:197:/Dockerfile	Dockerfile
```

No Python code is touched, so lint and type-check are unaffected.

## Findings not fixed here (deliberately out of scope)

Documented in `AGENTS.md` so agents work around them; each deserves its own PR:

1. **`tests/unit/test_haplo_count_and_selection.py` declares no `pytestmark`**, so its
   30 tests never run in CI. This is the "30 deselected" above — a one-line fix.
2. **`[tool.pytest.ini_options]` in `pyproject.toml` is dead config** — `pytest.ini`
   takes precedence, so `addopts = "-v --tb=short"` never applies.
3. **`make test-quiet` is broken** on pytest 9: `--log-cli=false` is rejected with
   `unrecognized arguments`.
4. **`vntyper report` raises `TypeError`** — `cli.py` passes `input_files=`,
   `pipeline_version=`, `mean_vntr_coverage=` to `generate_summary_report()`, which
   accepts none of them and requires a positional `log_file`.
5. **`CONTRIBUTING.md` setup instructions are wrong** — they reference a root
   `environment.yml` and a `vntyper-dev` env; neither exists. It also tells
   contributors to use a PR template that was never added.
6. `docs/about/changelog.md` is stale at 2.0.1 while the package is at 2.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW3Z5Gx2MBSzGzp38QMFKa

## Summary by Sourcery

Document agent-focused development workflow and fix repository ignores to support docs and agent configs.

Build:
- Adjust .gitignore to stop ignoring tracked MkDocs docs/ content, disambiguate Dockerfile rules, track shared agent configuration files, and ignore local adVNTR clones and per-developer agent overrides.

Documentation:
- Add AGENTS.md and CLAUDE.md to document setup, workflows, coding conventions, and pitfalls for automated coding agents.

Chores:
- Add shared Claude agent settings file to preconfigure common read-only and verification commands.