### PR TITLE
Agent scaffolding (AGENTS.md), .gitignore fixes, and CI repair

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(make lint)",
+      "Bash(make lint-stats)",
+      "Bash(make format)",
+      "Bash(make format-check)",
+      "Bash(make type-check)",
+      "Bash(make type-check-tests)",
+      "Bash(make type-check-all)",
+      "Bash(make test-unit)",
+      "Bash(make test-quiet)",
+      "Bash(make check-all)",
+      "Bash(make docs-build)",
+      "Bash(make help)",
+      "Bash(ruff check:*)",
+      "Bash(ruff format:*)",
+      "Bash(pytest -m unit:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git check-ignore:*)"
+    ],
+    "deny": [
+      "Bash(git push --tags:*)",
+      "Bash(git tag:*)",
+      "Bash(twine upload:*)",
+      "Read(./tests/data/**)",
+      "Read(./reference/**)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
+# NOTE: do NOT ignore docs/ itself - it holds the tracked MkDocs site sources.
 docs/_build/
-docs/
 
 # PyBuilder
 .pybuilder/
@@ -192,15 +192,23 @@ fastp.json
 /docker/test_output/
 /testing/
 
-# Local Dockerfile (for local development/testing)
-Dockerfile
+# Local Dockerfile at the repo root (for local development/testing).
+# Anchored so that the tracked docker/Dockerfile is never ignored.
+/Dockerfile
 
 # apptainer files
 *.sif
 
-# claude files and folders
-.claude/
-CLAUDE.md
+# coding-agent configuration
+# AGENTS.md, CLAUDE.md and .claude/settings.json are tracked on purpose - they are
+# shared project instructions. Only per-developer overrides stay local.
+.claude/settings.local.json
+.claude/state/
+.claude/*.local.json
+.mcp.local.json
+
+# local clone of the upstream adVNTR source tree (installed, not vendored)
+/adVNTR/
 
 # local development documentation and sensitive configs
 plan/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,14 +64,26 @@ collection time, so any other CWD breaks collection, including `-m unit`.
 
 - Ruff is the only formatter and linter. **Line length 120**, double quotes,
   `target-version = "py39"`. Do not reformat to black's 88.
+- `[tool.ruff.lint]` uses an explicit `select`, deliberately **not** `extend-select`.
+  Ruff's defaults shift between releases (0.16 turned on ~440 rules at once and took
+  CI from green to 740 errors with no code change). Add rules to `select` explicitly;
+  never rely on defaults. `BLE001` and `G004` are omitted on purpose — see the
+  rationale comment in `pyproject.toml`.
+- mypy is configured in `[tool.mypy]` in `pyproject.toml`, not via Makefile flags.
+  It targets 3.10 because mypy 2.x dropped 3.9; ruff's `target-version` still guards
+  the 3.9 runtime floor.
 - Code must run on Python 3.9 (CI matrix: 3.9–3.12). Your local interpreter is newer,
   so 3.10+ syntax can pass locally and break CI.
 - Google-style docstrings (`Args:` / `Returns:` / `Raises:`) on public functions.
-- Logging: modules call `logging.info(...)` on the root logger; configuration happens
-  once in `cli.py`. Do not add `basicConfig` or per-module handlers.
-- Errors: no custom exception classes. The convention is `logging.error(msg)` followed
+- Logging: every module declares `logger = logging.getLogger(__name__)` after its
+  imports and calls `logger.info(...)`. Never call `logging.info(...)` on the root
+  logger, and never add `basicConfig` or per-module handlers — `setup_logging()` in
+  `utils.py` configures the root logger once, and module loggers propagate to it.
+  f-strings in log calls are the established style here.
+- Errors: no custom exception classes. The convention is `logger.error(msg)` followed
   by `raise ValueError(msg)` / `RuntimeError(msg)` with the same message. Only exit
-  codes 0 and 1 are used.
+  codes 0 and 1 are used. `except Exception` at stage and process boundaries is
+  intentional, not an oversight.
 - Type hints are partial. Newer modules (`reference_registry`, `region_utils`,
   `scoring`, `flagging`) are fully annotated — match that when editing them.
 
@@ -111,8 +123,8 @@ collection time, so any other CWD breaks collection, including `-m unit`.
 
 1. **Config is loaded at import time.** `kestrel_genotyping.py`, `advntr_genotyping.py`
    and `shark_filtering.py` read their JSON into module globals on import, and
-   `run_kestrel()` uses `global kestrel_config` rather than its `config` argument.
-   `--config-path` cannot override them; tests must patch the module global.
+   `run_kestrel()` reads the module-level `kestrel_config` rather than its `config`
+   argument. `--config-path` cannot override them; tests must patch the module global.
 2. **`--config-path` replaces the whole config, it does not merge.** Missing keys raise
    `KeyError` deep in the pipeline (`config["tools"]["java_path"]`, no `.get`).
 3. **Rule strings are `eval()`d against DataFrame column names.** `flagging.py` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# AGENTS.md
+
+Instructions for coding agents working in this repository. Human contributors should
+read [CONTRIBUTING.md](CONTRIBUTING.md); everything below is the agent-facing summary
+plus the repo-specific traps that are easy to get wrong.
+
+## Project
+
+VNtyper genotypes the MUC1 coding VNTR to diagnose ADTKD-MUC1 from short-read data
+(BAM/CRAM/FASTQ). It runs mapping-free k-mer genotyping (Kestrel, vendored JAR),
+optionally validates with adVNTR, and emits confidence-scored calls plus an HTML report.
+
+Python package `vntyper`, one console entry point: `vntyper`. Version lives only in
+`vntyper/version.py`. Research use only — clinical-sounding output text is
+config-driven, never invent or reword it.
+
+## Setup
+
+The pipeline needs external binaries (bwa, samtools, fastp, bcftools, Java 11), so
+`pip install` alone does **not** give you a working pipeline:
+
+```bash
+mamba env create -f conda/environment_vntyper.yml   # env name: vntyper
+conda activate vntyper
+make install-dev                                    # pip install -e .[dev]
+```
+
+`CONTRIBUTING.md` still references a root `environment.yml` and a `vntyper-dev` env.
+Neither exists — use the commands above.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Full pre-PR gate | `make check-all` |
+| Format + autofix | `make format` |
+| Lint | `make lint` |
+| Type check | `make type-check` |
+| Fast tests (what CI runs) | `make test-unit` |
+| Integration tests | `make test-integration` |
+| Coverage | `make test-cov` |
+| Docs preview | `make docs-serve` |
+| Docs build (CI-equivalent) | `make docs-build` |
+
+Always run `make check-all` before opening a PR. Run pytest **from the repo root** —
+`tests/parametrization.py` opens `tests/test_data_config.json` by relative path at
+collection time, so any other CWD breaks collection, including `-m unit`.
+
+## Layout
+
+- `vntyper/cli.py` — argparse CLI; subcommands `pipeline`, `report`, `cohort`,
+  `install-references`, `online`. Sole place logging is configured.
+- `vntyper/scripts/pipeline.py` — `run_pipeline()`, orchestrates every stage.
+- `vntyper/scripts/` — stage modules: `fastq_bam_processing`, `alignment_processing`,
+  `kestrel_genotyping`, `variant_parsing`, `scoring`, `confidence_assignment`,
+  `motif_processing`, `flagging`, `summary`, `cross_match`, `generate_report`,
+  `cohort_summary`, `reference_registry`, `region_utils`, `chromosome_utils`.
+- `vntyper/modules/{advntr,shark}/` — optional `--extra-modules` stages.
+- `docker/app/` — the FastAPI + Celery web service. It is *not* part of the `vntyper`
+  package and is not covered by `make lint` / `make type-check`.
+- `vntyper/dependencies/kestrel/` — vendored JARs, never hand-edit.
+
+## Code style
+
+- Ruff is the only formatter and linter. **Line length 120**, double quotes,
+  `target-version = "py39"`. Do not reformat to black's 88.
+- Code must run on Python 3.9 (CI matrix: 3.9–3.12). Your local interpreter is newer,
+  so 3.10+ syntax can pass locally and break CI.
+- Google-style docstrings (`Args:` / `Returns:` / `Raises:`) on public functions.
+- Logging: modules call `logging.info(...)` on the root logger; configuration happens
+  once in `cli.py`. Do not add `basicConfig` or per-module handlers.
+- Errors: no custom exception classes. The convention is `logging.error(msg)` followed
+  by `raise ValueError(msg)` / `RuntimeError(msg)` with the same message. Only exit
+  codes 0 and 1 are used.
+- Type hints are partial. Newer modules (`reference_registry`, `region_utils`,
+  `scoring`, `flagging`) are fully annotated — match that when editing them.
+
+## Testing
+
+- `pytest.ini` at the repo root is the live config. The `[tool.pytest.ini_options]`
+  block in `pyproject.toml` is **dead** — pytest.ini takes precedence. Edit `pytest.ini`.
+- Markers: `unit`, `integration`, `docker`, `slow`.
+- **Every new unit test file must declare `pytestmark = pytest.mark.unit`.** CI runs
+  `pytest -m unit`, so an unmarked file silently never runs.
+  (`tests/unit/test_haplo_count_and_selection.py` is currently unmarked — 30 tests
+  invisible to CI.)
+- Unit tests must stay pure: `tmp_path` + `unittest.mock`, no network, no reference data.
+- Integration and docker tests pull a ~1.1 GB Zenodo archive and MD5 all 114 files; one
+  missing file triggers a full re-download. There are **no** `pytest.skip` guards
+  anywhere — missing data calls `pytest.exit()` and kills the whole session, unit tests
+  included. Set `VNTYPER_TEST_DATA_SKIP_DOWNLOAD=1` to fail fast instead of downloading.
+- Correct marker composition is `-m "docker and not slow"`; repeated `-m` flags override
+  rather than combine.
+
+## Git and PRs
+
+- Branch from `main` (there is no `develop` despite the CI trigger list). Observed
+  naming: `fix/issue-145-flagging-before-selection`, `test/issue-156-gdp-inflation-guard`,
+  `docs/mkdocs-site`. Use `<type>/issue-<N>-<slug>` or `<type>/<slug>`.
+- Conventional Commits: `type(scope): lowercase subject` under ~72 chars, with
+  `Closes #N` in the footer. Scopes are module or area names (`kestrel`, `flagging`,
+  `config`, `ci`, `docker`).
+- PRs are **not** squashed — every commit becomes permanent history. Keep them clean.
+- Copilot and Sourcery AI review PRs. The established pattern is a follow-up commit
+  addressing their comments, not a force-push.
+- CI gates on PRs: `make lint`, `make type-check`, `make test-unit` across 3.9–3.12,
+  plus a Docker image build and quick Docker tests. Formatting is *not* gated in CI —
+  run `make format-check` yourself.
+
+## Traps
+
+1. **Config is loaded at import time.** `kestrel_genotyping.py`, `advntr_genotyping.py`
+   and `shark_filtering.py` read their JSON into module globals on import, and
+   `run_kestrel()` uses `global kestrel_config` rather than its `config` argument.
+   `--config-path` cannot override them; tests must patch the module global.
+2. **`--config-path` replaces the whole config, it does not merge.** Missing keys raise
+   `KeyError` deep in the pipeline (`config["tools"]["java_path"]`, no `.get`).
+3. **Rule strings are `eval()`d against DataFrame column names.** `flagging.py` and
+   `cross_match.py` evaluate expressions from `kestrel_config.json`,
+   `advntr_config.json` and `config.json`. Renaming a column silently turns flags off —
+   a `NameError` only logs a warning. Grep the JSON configs before renaming any column.
+4. **Stages mark, they do not filter.** Kestrel stages append boolean columns
+   (`is_frameshift`, `is_valid_frameshift`, `depth_confidence_pass`, `alt_filter_pass`,
+   `motif_filter_pass`); `filter_final_dataframe()` ANDs them at the end. Preserve that
+   contract — dropping rows early breaks `kestrel_pre_result.tsv` debuggability.
+5. **Summary step names are string literals.** `"Kestrel Genotyping"`,
+   `"adVNTR Genotyping"`, `"Coverage Calculation"`, `"BAM Header Parsing"`,
+   `"Cross-Match Variant Comparison"` are matched exactly by `generate_report.py`,
+   `cohort_summary.py` and `cross_match.py`. All `parsed_result` values are strings.
+6. **Conda env names are load-bearing.** `config.json` shells out to
+   `mamba run -n envadvntr advntr` and `mamba run -n shark_env shark`. `envadvntr` is
+   Python 2.7 and can never be merged into the main env.
+7. **All tool and reference paths in `config.json` are relative to the process CWD.**
+   `pipeline.py` pins `project_root = os.getcwd()` and threads it as `cwd=` into Java
+   and samtools calls — do not remove that plumbing.
+8. **Kestrel is pinned to 1.0.1.** Scoring thresholds are calibrated to it; 1.0.2 output
+   differs. Do not upgrade the JAR.
+9. **`run_command` uses `shell=True`** deliberately, for process substitution in the CRAM
+   unmapped-read path. Converting it to `shell=False` breaks that branch.
+10. **The Docker build clones from GitHub**, it does not build your local checkout. Only
+    `docker/entrypoint.sh` and `docker/app/` come from the local context.
+11. **`vntyper report` is currently broken** — `cli.py` passes arguments
+    `generate_summary_report()` does not accept. Do not copy that call site as an example.
+12. **Version lives in three places**: `vntyper/version.py` (authoritative),
+    `CITATION.cff`, and `docs/about/changelog.md` (currently stale at 2.0.1).
+
+## Never
+
+- Never push a `v*.*.*` tag. It publishes to PyPI immediately and irreversibly.
+- Never commit into `tests/data/`, `reference/`, `out/`, `download/`, `vntyper.egg-info/`
+  or the local `adVNTR/` clone — all are generated or downloaded.
+- Never hand-edit `vntyper/dependencies/kestrel/*.jar` or anything in `vntyper.egg-info/`.
+- Never add a page under `docs/` without registering it in `mkdocs.yml` `nav:` —
+  the docs workflow runs `mkdocs build --strict`, so a dangling nav entry or broken
+  internal link fails CI.
+- Never claim tests pass without showing the command output.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ authors:
     orcid: "https://orcid.org/0000-0002-3679-1081"
 repository-code: "https://github.com/hassansaei/VNtyper"
 license: BSD-3-Clause
-version: "2.0.3"
-date-released: "2026-03-22"
+version: "2.0.4"
+date-released: "2026-08-05"
 doi: "10.5281/zenodo.19744166"
 identifiers:
   - type: doi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+Project instructions for this repository live in **[AGENTS.md](AGENTS.md)**. Read it
+before making any change — it is the single source of truth for setup, commands, code
+style, testing, git conventions, and the repo-specific traps.
+
+This file exists only so Claude Code picks the instructions up automatically. Keep it a
+pointer: add new guidance to `AGENTS.md`, not here.
+
+Quick reference:
+
+- Verify with `make check-all` before proposing a PR.
+- Fast feedback loop: `make format && make test-unit`, run from the repo root.
+- The pipeline needs the `vntyper` conda env; `pip install -e .[dev]` alone is not enough.

--- a/Makefile
+++ b/Makefile
@@ -95,17 +95,17 @@ format-check:
 # Type checking targets
 type-check:
 	@echo "$(BLUE)Running mypy type checker on vntyper package...$(RESET)"
-	mypy vntyper/ --python-version 3.9 --ignore-missing-imports
+	mypy vntyper/
 	@echo "$(GREEN)✓ Type checking complete$(RESET)"
 
 type-check-tests:
 	@echo "$(BLUE)Running mypy type checker on tests...$(RESET)"
-	mypy tests/ --python-version 3.9 --ignore-missing-imports
+	mypy tests/
 	@echo "$(GREEN)✓ Type checking complete$(RESET)"
 
 type-check-all:
 	@echo "$(BLUE)Running mypy type checker on all code...$(RESET)"
-	mypy vntyper/ tests/ --python-version 3.9 --ignore-missing-imports
+	mypy vntyper/ tests/
 	@echo "$(GREEN)✓ Type checking complete$(RESET)"
 
 # Test data management targets
@@ -166,7 +166,7 @@ test-cov:
 
 test-quiet:
 	@echo "$(BLUE)Running tests with minimal output...$(RESET)"
-	pytest --log-cli=false -q
+	pytest -o log_cli=false -q
 	@echo "$(GREEN)✓ Tests complete$(RESET)"
 
 test-verbose:

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -2,7 +2,37 @@
 
 All notable changes to VNtyper 2 are documented on this page.
 
-## 2.0.1 (Current)
+## 2.0.4 (Current)
+
+- Migrated all logging to per-module loggers (`logging.getLogger(__name__)`); log
+  records now carry the emitting module name instead of `root`.
+- Replaced deprecated `datetime.utcnow()` calls; emitted timestamps are unchanged.
+- Ruff lint rules are now selected explicitly instead of extending ruff's defaults, so
+  lint results no longer change when ruff widens its default rule set.
+- mypy configuration moved from Makefile flags into `pyproject.toml`.
+- Fixed `.gitignore` ignoring the tracked `docs/` directory, which silently hid newly
+  added documentation pages from Git.
+- Fixed `make test-quiet`, which used a `--log-cli=false` flag pytest does not accept.
+- Added `AGENTS.md` and `CLAUDE.md` with repository instructions for coding agents.
+
+## 2.0.3
+
+- Raised Kestrel max align and haplotype states to 40, fixing GDP inflation
+  ([#156](https://github.com/hassansaei/VNtyper/issues/156)).
+- Handled `pd.NA` and `None` in flagging condition evaluation to prevent `TypeError`s.
+- Added a GDP inflation guard test with an anonymized hg38 sample.
+- Added `CITATION.cff` with the Zenodo concept DOI.
+
+## 2.0.2
+
+- Removed specific motifs from `exclude_motifs_right` to prevent unwanted motif filtering.
+- Clarified depth score conditions in confidence assignment
+  ([#154](https://github.com/hassansaei/VNtyper/issues/154)).
+- Added a dynamic version variable to the docs via `mkdocs-macros-plugin`.
+- Modernized docs deployment to use GitHub Actions Pages.
+- Added a CFLAGS workaround for adVNTR compilation errors on GCC 14+.
+
+## 2.0.1
 
 - Disabled duplicate flagging in Kestrel configuration.
 - Cleared `motifs_for_alt_gg` array to prevent unintended variant filtering.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,22 +116,54 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-# Ruff's default select = ["E4", "E7", "E9", "F"]
-# Extend with additional modern Python rules (more composable)
-extend-select = [
+# Use an explicit `select`, NOT `extend-select`. `extend-select` builds on ruff's
+# default rule set, which ruff is free to change between releases - ruff 0.16
+# expanded its defaults and turned ~440 unrequested rules on at once, taking CI from
+# green to 740 errors without a single line of code changing. Listing rules
+# explicitly makes lint results reproducible across ruff versions.
+select = [
+    # --- ruff's historical defaults, now pinned explicitly ---
+    "E4",   # pycodestyle: imports
+    "E7",   # pycodestyle: statements
+    "E9",   # pycodestyle: runtime errors
+    "F",    # pyflakes
+    # --- long-standing project opt-ins ---
     "W",    # pycodestyle warnings
     "B",    # flake8-bugbear (detect common bugs)
     "I",    # isort (import sorting)
     "UP",   # pyupgrade (modern Python syntax)
     "SIM",  # flake8-simplify (simplify code)
+    # --- adopted when ruff 0.16 surfaced them; the code now satisfies these ---
+    "LOG",  # flake8-logging: no calls on the root logger
+    "DTZ",  # flake8-datetimez: no naive/deprecated datetime calls
+    "EXE",  # flake8-executable: no shebangs on non-executable modules
+    "FA",   # flake8-future-annotations
+    "C4",   # flake8-comprehensions
+    "PIE",  # flake8-pie
+    "PERF", # perflint
+    "FURB", # refurb
+    "G201",    # .exception() over .error(..., exc_info=True)
+    "TRY201",  # bare `raise` when re-raising
+    "TRY401",  # redundant exception object in .exception()
+    "PLW0602", # `global` without assignment
+    "PLW1510", # subprocess.run without explicit check=
 ]
 
-# Ignore docstring rules for now (can enable gradually)
-# Note: E501 (line too long) is automatically ignored when formatter is enabled
+# Note: E501 (line too long) is automatically ignored when the formatter is enabled.
 ignore = [
     "D100", "D104",  # Missing docstrings (enable later if desired)
     "D200", "D202", "D205", "D400", "D401",  # Docstring formatting
+    # Deliberate, not accidental:
+    "PERF203",  # try/except inside a loop - the pipeline needs per-iteration
+                # error handling so one bad sample cannot abort a whole cohort.
 ]
+
+# Rules deliberately NOT selected, so the omission is a decision and not an oversight:
+#   BLE001 (blind-except) - `except Exception` at stage and process boundaries is the
+#     project's intended error-handling contract (log, then exit 1). Narrowing all 46
+#     handlers needs per-call knowledge of what each external tool raises.
+#   G004 (logging-f-string) - f-strings in log calls are the established style across
+#     all ~600 log statements.
 
 # Allow auto-fix for all rules by default
 fixable = ["ALL"]
@@ -141,6 +173,19 @@ unfixable = []
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "E402"]  # Allow unused imports
 "tests/**/*.py" = ["S101"]        # Allow assert statements in tests
+
+# ===========================
+# mypy Configuration
+# ===========================
+# Previously passed as CLI flags from three separate Makefile targets, which drifted:
+# they hardcoded `--python-version 3.9`, and mypy 2.x dropped support for targeting
+# 3.9 ("must be 3.10 or higher"), breaking CI. Configure it once here instead.
+[tool.mypy]
+# The runtime floor stays 3.9 (see `requires-python` and the CI matrix); this is only
+# the version mypy type-checks against, and 3.10 is the oldest it still supports.
+# Ruff's `target-version = "py39"` remains the guard against 3.10+ syntax.
+python_version = "3.10"
+ignore_missing_imports = true
 
 [tool.ruff.format]
 # Use double quotes (Python default)

--- a/tests/TESTING_GUIDE.md
+++ b/tests/TESTING_GUIDE.md
@@ -165,7 +165,7 @@ pytest --log-cli-level=DEBUG
 pytest --log-cli-level=WARNING
 
 # Disable live logging entirely
-pytest --log-cli=false
+pytest -o log_cli=false
 ```
 
 ## Troubleshooting Slow/Stuck Tests

--- a/vntyper/cli.py
+++ b/vntyper/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/cli.py
 # VNtyper CLI entry point
 
@@ -22,6 +21,8 @@ from vntyper.scripts.reference_registry import list_assemblies
 from vntyper.scripts.utils import setup_logging
 from vntyper.version import __version__ as VERSION
 
+logger = logging.getLogger(__name__)
+
 
 def load_config(config_path=None):
     """
@@ -36,16 +37,16 @@ def load_config(config_path=None):
     if config_path is not None and Path(config_path).exists():
         with open(config_path, encoding="utf-8") as f:
             config = json.load(f)
-        logging.debug(f"Loaded configuration from {config_path}")
+        logger.debug(f"Loaded configuration from {config_path}")
     else:
         # No config path provided or file does not exist; use default config from package data
         try:
             with pkg_resources.open_text("vntyper", "config.json") as f:
                 config = json.load(f)
-            logging.debug("Loaded default configuration from package data.")
+            logger.debug("Loaded default configuration from package data.")
         except Exception as exc:
-            logging.error("Error: Default config file not found in package data.")
-            logging.error(exc)
+            logger.error("Error: Default config file not found in package data.")
+            logger.error(exc)
             sys.exit(1)
     return config
 
@@ -369,9 +370,9 @@ def main():
     try:
         # IMPORTANT: Use `initial_config` as fallback when `--config-path` is not provided
         config = load_config(args.config_path) if args.config_path else load_config(None)
-        logging.debug("Configuration loaded successfully.")
+        logger.debug("Configuration loaded successfully.")
     except Exception as exc:
-        logging.critical(f"Failed to load configuration: {exc}")
+        logger.critical(f"Failed to load configuration: {exc}")
         sys.exit(1)
 
     def get_conf(key, fallback):
@@ -409,14 +410,14 @@ def main():
 
     # Setup logging now (only once) with the determined log level and log file
     setup_logging(log_level=log_level_value, log_file=log_file_str)
-    logging.debug(f"Logging has been set up with level {log_level_value} and log_file {log_file_str}")
+    logger.debug(f"Logging has been set up with level {log_level_value} and log_file {log_file_str}")
 
     # Log current logging handlers and their levels
     for handler in logging.getLogger().handlers:
         handler_type = handler.__class__.__name__
         handler_level = logging.getLevelName(handler.level)
         handler_file = getattr(handler, "baseFilename", "N/A") if isinstance(handler, logging.FileHandler) else "N/A"
-        logging.debug(f"Handler: {handler_type}, Level: {handler_level}, File: {handler_file}")
+        logger.debug(f"Handler: {handler_type}, Level: {handler_level}, File: {handler_file}")
 
     # Subcommand: install-references
     if args.command == "install-references":
@@ -440,30 +441,30 @@ def main():
         if not args.log_file and args.output_dir:
             log_file = Path(args.output_dir) / "pipeline.log"
             log_file.parent.mkdir(parents=True, exist_ok=True)
-            logging.debug(f"Setting log file to {log_file}")
+            logger.debug(f"Setting log file to {log_file}")
 
         if args.output_dir is None:
             args.output_dir = get_conf("output_dir", "out")
-            logging.debug(f"output_dir set to {args.output_dir}")
+            logger.debug(f"output_dir set to {args.output_dir}")
         if args.threads is None:
             args.threads = get_conf("threads", 4)
-            logging.debug(f"threads set to {args.threads}")
+            logger.debug(f"threads set to {args.threads}")
         if args.reference_assembly is None:
             args.reference_assembly = get_conf("reference_assembly", "hg19")
-            logging.debug(f"reference_assembly set to {args.reference_assembly}")
+            logger.debug(f"reference_assembly set to {args.reference_assembly}")
         if args.output_name is None:
             args.output_name = get_conf("output_name", "processed")
-            logging.debug(f"output_name set to {args.output_name}")
+            logger.debug(f"output_name set to {args.output_name}")
         if args.archive_format is None:
             args.archive_format = get_conf("archive_format", "zip")
-            logging.debug(f"archive_format set to {args.archive_format}")
+            logger.debug(f"archive_format set to {args.archive_format}")
 
         import itertools
 
         flattened_modules = list(
             itertools.chain.from_iterable(m if isinstance(m, list) else [m] for m in args.extra_modules)
         )
-        logging.debug(f"extra_modules flattened to {flattened_modules}")
+        logger.debug(f"extra_modules flattened to {flattened_modules}")
 
         # Validate single input type
         input_types = sum(
@@ -475,14 +476,14 @@ def main():
         )
         if input_types > 1:
             parser.error("Provide either BAM, CRAM, or FASTQ files (not multiples).")
-            logging.debug("Multiple input types detected.")
+            logger.debug("Multiple input types detected.")
             sys.exit(1)
 
         if not args.bam and not args.cram and (args.fastq1 is None or args.fastq2 is None):
             parser.error(
                 "When not providing BAM/CRAM, both --fastq1 and --fastq2 must be specified for paired-end sequencing."
             )
-            logging.debug("Missing FASTQ files for paired-end sequencing.")
+            logger.debug("Missing FASTQ files for paired-end sequencing.")
             sys.exit(1)
 
         # Construct module_args_dict for advntr, etc.
@@ -494,21 +495,21 @@ def main():
             if hasattr(args, "advntr_reference"):
                 module_args_dict["advntr"]["advntr_reference"] = args.advntr_reference
                 delattr(args, "advntr_reference")
-                logging.debug(f"advntr_reference set to {args.advntr_reference}")
+                logger.debug(f"advntr_reference set to {args.advntr_reference}")
 
             # The new coverage parameter:
             if args.advntr_max_coverage:
                 module_args_dict["advntr"]["max_coverage"] = args.advntr_max_coverage
-                logging.debug(f"advntr_max_coverage set to {args.advntr_max_coverage}")
+                logger.debug(f"advntr_max_coverage set to {args.advntr_max_coverage}")
 
         else:
             module_args_dict["advntr"] = {}
-            logging.debug("advntr module not included.")
+            logger.debug("advntr module not included.")
 
         # (#62) If user tries to use 'shark' in BAM/CRAM mode, exit with a warning
         if (args.bam or args.cram) and ("shark" in flattened_modules):
-            logging.warning("Shark is not supported in BAM mode; please use FASTQ mode or remove the shark flag.")
-            logging.debug("Shark module detected with BAM/CRAM input; exiting.")
+            logger.warning("Shark is not supported in BAM mode; please use FASTQ mode or remove the shark flag.")
+            logger.debug("Shark module detected with BAM/CRAM input; exiting.")
             sys.exit(1)
 
         # Determine which BWA reference to use from config using registry
@@ -517,7 +518,7 @@ def main():
         try:
             coord_system = get_coordinate_system(args.reference_assembly)
         except ValueError:
-            logging.warning(f"Unknown assembly '{args.reference_assembly}', defaulting to GRCh37")
+            logger.warning(f"Unknown assembly '{args.reference_assembly}', defaulting to GRCh37")
             coord_system = "GRCh37"
 
         # Map coordinate system to UCSC-style name for BWA reference lookup
@@ -525,19 +526,19 @@ def main():
         ucsc_style_ref = ucsc_map.get(coord_system, "hg19")
         bwa_key = f"bwa_reference_{ucsc_style_ref}"
         bwa_reference = config.get("reference_data", {}).get(bwa_key)
-        logging.debug(f"Using BWA reference {bwa_key}: {bwa_reference}")
+        logger.debug(f"Using BWA reference {bwa_key}: {bwa_reference}")
 
         sample_name_val = args.sample_name
         if sample_name_val is None:
             if args.bam:
                 sample_name_val = Path(args.bam).stem
-                logging.debug(f"sample_name set from BAM file: {sample_name_val}")
+                logger.debug(f"sample_name set from BAM file: {sample_name_val}")
             elif args.fastq1:
                 sample_name_val = Path(args.fastq1).stem
-                logging.debug(f"sample_name set from FASTQ1 file: {sample_name_val}")
+                logger.debug(f"sample_name set from FASTQ1 file: {sample_name_val}")
             else:
                 sample_name_val = "sample"
-                logging.debug(f"sample_name defaulted to: {sample_name_val}")
+                logger.debug(f"sample_name defaulted to: {sample_name_val}")
 
         # Process the new --summary-formats argument (comma-separated)
         summary_formats = []
@@ -581,10 +582,10 @@ def main():
         # (we do so only if relevant keys exist in config["default_values"])
         if args.report_file is None:
             args.report_file = get_conf("report_file", "summary_report.html")
-            logging.debug(f"report_file set to {args.report_file}")
+            logger.debug(f"report_file set to {args.report_file}")
         if args.flanking is None:
             args.flanking = get_conf("flanking", 50)
-            logging.debug(f"flanking set to {args.flanking}")
+            logger.debug(f"flanking set to {args.flanking}")
 
         # If user did not provide reference_fasta, fallback to config if present
         if args.reference_fasta is None:
@@ -592,7 +593,7 @@ def main():
             ref_fasta = config.get("reference_data", {}).get("muc1_reference_vntr")
             if ref_fasta:
                 args.reference_fasta = Path(ref_fasta)
-                logging.debug(f"reference_fasta set to {args.reference_fasta}")
+                logger.debug(f"reference_fasta set to {args.reference_fasta}")
 
         # If user didn't specify --bam-file, we attempt to find a standard location
         # e.g. <input-dir>/kestrel/output.bam
@@ -601,14 +602,14 @@ def main():
             candidate_bam = args.input_dir / "kestrel" / "output.bam"
             if candidate_bam.exists():
                 args.bam_file = candidate_bam
-                logging.debug(f"bam_file set to {args.bam_file}")
+                logger.debug(f"bam_file set to {args.bam_file}")
 
         # Same approach for bed-file (standard name is "output.bed" in "kestrel")
         if args.bed_file is None and args.input_dir:
             candidate_bed = args.input_dir / "kestrel" / "output.bed"
             if candidate_bed.exists():
                 args.bed_file = candidate_bed
-                logging.debug(f"bed_file set to {args.bed_file}")
+                logger.debug(f"bed_file set to {args.bed_file}")
 
         # Now call generate_summary_report
         generate_summary_report(
@@ -634,21 +635,21 @@ def main():
     elif args.command == "cohort":
         if args.summary_file is None:
             args.summary_file = get_conf("summary_file", "cohort_summary.html")
-            logging.debug(f"summary_file set to {args.summary_file}")
+            logger.debug(f"summary_file set to {args.summary_file}")
 
         # Prepare the list of input paths
         input_paths = []
         if args.input_dirs:
             input_paths.extend(args.input_dirs)
-            logging.debug(f"Added input_dirs: {args.input_dirs}")
+            logger.debug(f"Added input_dirs: {args.input_dirs}")
         if args.input_file:
             if not args.input_file.exists():
-                logging.error(f"The input file {args.input_file} does not exist.")
+                logger.error(f"The input file {args.input_file} does not exist.")
                 sys.exit(1)
             with open(args.input_file) as f:
                 file_lines = [line.strip() for line in f if line.strip()]
                 input_paths.extend(file_lines)
-            logging.debug(f"Added input_file entries: {file_lines}")
+            logger.debug(f"Added input_file entries: {file_lines}")
 
         aggregate_cohort(
             input_paths=input_paths,
@@ -669,13 +670,13 @@ def main():
 
         if args.output_dir is None:
             args.output_dir = get_conf("output_dir", "out")
-            logging.debug(f"output_dir set to {args.output_dir}")
+            logger.debug(f"output_dir set to {args.output_dir}")
         if args.reference_assembly is None:
             args.reference_assembly = get_conf("reference_assembly", "hg19")
-            logging.debug(f"reference_assembly set to {args.reference_assembly}")
+            logger.debug(f"reference_assembly set to {args.reference_assembly}")
         if args.threads is None:
             args.threads = get_conf("threads", 4)
-            logging.debug(f"threads set to {args.threads}")
+            logger.debug(f"threads set to {args.threads}")
 
         run_online_mode(
             config=config,
@@ -690,7 +691,7 @@ def main():
         )
 
     else:
-        logging.error(f"Unknown command: {args.command}")
+        logger.error(f"Unknown command: {args.command}")
         parser.print_help()
         sys.exit(1)
 

--- a/vntyper/modules/advntr/__init__.py
+++ b/vntyper/modules/advntr/__init__.py
@@ -1,7 +1,7 @@
 # vntyper/modules/advntr/__init__.py
 # This file makes 'advntr' a subpackage of 'modules'
 
-from .advntr_genotyping import (  # noqa: F401
+from .advntr_genotyping import (
     load_advntr_config,
     process_advntr_output,
     run_advntr,

--- a/vntyper/modules/advntr/advntr_genotyping.py
+++ b/vntyper/modules/advntr/advntr_genotyping.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/modules/advntr/advntr_genotyping.py
 
 import logging
@@ -11,12 +10,10 @@ import pandas as pd
 
 from vntyper.scripts.utils import load_config, run_command
 
-# -------------------------------------------------------------------------
-# Configure logging
-# -------------------------------------------------------------------------
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 
+# -------------------------------------------------------------------------
 def load_advntr_config(config_path=None):
     """
     Loads the adVNTR configuration file.
@@ -65,17 +62,17 @@ def run_advntr(db_file, sorted_bam, output, output_name, config, cwd=None):
     # Validate input paths before proceeding
     # ---------------------------------------------------------------------
     if not os.path.isfile(db_file):
-        logging.critical(f"VNTR database file not found: {db_file}")
+        logger.critical(f"VNTR database file not found: {db_file}")
         return 1
     if not os.path.isfile(sorted_bam):
-        logging.critical(f"Sorted BAM file not found: {sorted_bam}")
+        logger.critical(f"Sorted BAM file not found: {sorted_bam}")
         return 1
     if not os.path.isdir(output):
-        logging.warning(f"Output directory does not exist, creating: {output}")
+        logger.warning(f"Output directory does not exist, creating: {output}")
         try:
             os.makedirs(output, exist_ok=True)
         except Exception as e:
-            logging.critical(f"Could not create output directory {output}: {e}")
+            logger.critical(f"Could not create output directory {output}: {e}")
             return 1
 
     advntr_command = (
@@ -87,22 +84,22 @@ def run_advntr(db_file, sorted_bam, output, output_name, config, cwd=None):
     # Define log file for adVNTR output
     log_file = os.path.join(output, f"{output_name}_advntr.log")
 
-    logging.info("Launching adVNTR genotyping...")
-    logging.debug(f"Command: {advntr_command}")
+    logger.info("Launching adVNTR genotyping...")
+    logger.debug(f"Command: {advntr_command}")
 
     try:
         # Run the adVNTR command and log output to the specified log file
         if not run_command(advntr_command, log_file, critical=True, cwd=cwd):
-            logging.error("adVNTR genotyping failed. Check the log for details.")
+            logger.error("adVNTR genotyping failed. Check the log for details.")
             return 1
     except sp.CalledProcessError as cpe:
-        logging.error(f"adVNTR genotyping CalledProcessError: {cpe}")
+        logger.error(f"adVNTR genotyping CalledProcessError: {cpe}")
         return 1
     except Exception as e:
-        logging.error(f"adVNTR genotyping encountered an unexpected error: {e}")
+        logger.error(f"adVNTR genotyping encountered an unexpected error: {e}")
         return 1
 
-    logging.info("adVNTR genotyping of MUC1-VNTR completed successfully.")
+    logger.info("adVNTR genotyping of MUC1-VNTR completed successfully.")
     return 0
 
 
@@ -117,7 +114,6 @@ def advntr_processing_del(df):
     Returns:
         pd.DataFrame: Filtered DataFrame containing only those deletions that pass the frameshift filter.
     """
-    logger = logging.getLogger(__name__)
     logger.debug("Starting deletion processing.")
     df1 = df.copy()
     logger.debug("Copied input DataFrame for deletion processing.")
@@ -157,7 +153,6 @@ def advntr_processing_ins(df):
     Returns:
         pd.DataFrame: Filtered DataFrame containing only those insertions that pass the frameshift filter.
     """
-    logger = logging.getLogger(__name__)
     logger.debug("Starting insertion processing.")
     df1 = df.copy()
     logger.debug("Copied input DataFrame for insertion processing.")
@@ -206,7 +201,7 @@ def load_ru_sequences(ru_fasta_path):
                 if current_ru and seq_lines:
                     ru_dict[current_ru] = "".join(seq_lines)
                 header = line[1:]
-                current_ru = header[2:] if header.startswith("RU") else header
+                current_ru = header.removeprefix("RU")
                 seq_lines = []
             else:
                 seq_lines.append(line)
@@ -307,10 +302,10 @@ def process_advntr_output(output_path, output, output_name, config=None):
         config (dict, optional): Main configuration dictionary.
     """
     if not os.path.exists(output_path):
-        logging.error(f"adVNTR output file {output_path} not found!")
+        logger.error(f"adVNTR output file {output_path} not found!")
         return
 
-    logging.info("Processing adVNTR result...")
+    logger.info("Processing adVNTR result...")
 
     with open(output_path) as file:
         content = file.readlines()
@@ -321,12 +316,12 @@ def process_advntr_output(output_path, output, output_name, config=None):
         file.writelines(content)
 
     try:
-        logging.info("Loading data into DataFrame...")
+        logger.info("Loading data into DataFrame...")
         df = pd.read_csv(output_path, sep="\t", comment="#")
-        logging.info(f"Data loaded successfully with shape: {df.shape}")
-        logging.debug(f"First few rows of the DataFrame:\n{df.head()}")
+        logger.info(f"Data loaded successfully with shape: {df.shape}")
+        logger.debug(f"First few rows of the DataFrame:\n{df.head()}")
     except Exception as e:
-        logging.error(f"Error loading data into DataFrame: {e}")
+        logger.error(f"Error loading data into DataFrame: {e}")
         return
 
     # Immediately check if the loaded DataFrame is empty
@@ -343,7 +338,7 @@ def process_advntr_output(output_path, output, output_name, config=None):
         "Flag",
     ]
     if df.empty:
-        logging.warning("VCF file is empty. Generating default negative result.")
+        logger.warning("VCF file is empty. Generating default negative result.")
         advntr_concat = pd.DataFrame(
             [
                 {
@@ -363,22 +358,22 @@ def process_advntr_output(output_path, output, output_name, config=None):
         output_result_path = os.path.join(output, f"{output_name}_adVNTR_result.tsv")
         advntr_concat = advntr_concat[final_columns]
         advntr_concat.to_csv(output_result_path, sep="\t", index=False)
-        logging.info(f"Processed adVNTR results saved to {output_result_path}")
+        logger.info(f"Processed adVNTR results saved to {output_result_path}")
         cleanup_files(output, output_name)
         return
 
     try:
-        logging.info("Processing deletions...")
+        logger.info("Processing deletions...")
         df_del = advntr_processing_del(df)
 
-        logging.info("Processing insertions...")
+        logger.info("Processing insertions...")
         df_ins = advntr_processing_ins(df)
 
-        logging.info("Concatenating deletions and insertions...")
+        logger.info("Concatenating deletions and insertions...")
         advntr_concat = pd.concat([df_del, df_ins], axis=0)
 
         if advntr_concat.empty:
-            logging.warning("No pathogenic variant found after filtering. Generating default negative result.")
+            logger.warning("No pathogenic variant found after filtering. Generating default negative result.")
             advntr_concat = pd.DataFrame(
                 [
                     {
@@ -404,14 +399,14 @@ def process_advntr_output(output_path, output, output_name, config=None):
                 "Pvalue",
             ]
             advntr_concat = advntr_concat[base_columns]
-            logging.info("Removing duplicates...")
+            logger.info("Removing duplicates...")
             advntr_concat.drop_duplicates(subset=["VID", "Variant", "NumberOfSupportingReads"], inplace=True)
 
             # Perform RU-level annotation if possible
             if config:
                 ru_fasta_path = config.get("reference_data", {}).get("code_adVNTR_RUs")
                 if ru_fasta_path and os.path.exists(ru_fasta_path):
-                    logging.info("Annotating variants with RU-level information.")
+                    logger.info("Annotating variants with RU-level information.")
                     ru_ann, pos_ann, ref_ann, alt_ann = annotate_advntr_variants(
                         advntr_concat["Variant"], ru_fasta_path
                     )
@@ -423,7 +418,7 @@ def process_advntr_output(output_path, output, output_name, config=None):
             # Apply flagging rules if available
             flagging_rules = advntr_config.get("flagging_rules", {})
             if flagging_rules:
-                logging.info("Applying flagging rules to adVNTR output.")
+                logger.info("Applying flagging rules to adVNTR output.")
                 from vntyper.scripts.flagging import add_flags
 
                 advntr_concat = add_flags(advntr_concat, flagging_rules)
@@ -436,9 +431,9 @@ def process_advntr_output(output_path, output, output_name, config=None):
         advntr_concat = advntr_concat[final_columns]
         output_result_path = os.path.join(output, f"{output_name}_adVNTR_result.tsv")
         advntr_concat.to_csv(output_result_path, sep="\t", index=False)
-        logging.info(f"Processed adVNTR results saved to {output_result_path}")
+        logger.info(f"Processed adVNTR results saved to {output_result_path}")
     except Exception as e:
-        logging.error(f"Error during processing of deletions and insertions: {e}")
+        logger.error(f"Error during processing of deletions and insertions: {e}")
         return
 
     cleanup_files(output, output_name)
@@ -452,4 +447,4 @@ def cleanup_files(output, output_name):
         output (str): The output directory.
         output_name (str): The base name for the output files.
     """
-    logging.info("Intermediate files cleaned up.")
+    logger.info("Intermediate files cleaned up.")

--- a/vntyper/modules/shark/__init__.py
+++ b/vntyper/modules/shark/__init__.py
@@ -1,4 +1,4 @@
 # vntyper/modules/shark/__init__.py
 # This file makes 'shark' a subpackage of 'modules'
 
-from .shark_filtering import run_shark_filter  # noqa: F401
+from .shark_filtering import run_shark_filter

--- a/vntyper/modules/shark/shark_filtering.py
+++ b/vntyper/modules/shark/shark_filtering.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/modules/shark/shark_filtering.py
 
 import logging
@@ -6,6 +5,8 @@ import os
 from pathlib import Path
 
 from vntyper.scripts.utils import load_config, run_command
+
+logger = logging.getLogger(__name__)
 
 
 def load_shark_config(config_path=None):
@@ -73,11 +74,11 @@ def run_shark_filter(
     )
 
     log_file = Path(output_dir) / f"{sample_name}_shark.log"
-    logging.info(f"Running SHARK filtering with command: {command}")
+    logger.info(f"Running SHARK filtering with command: {command}")
 
     success = run_command(command, str(log_file), critical=True)
     if not success:
-        logging.error("SHARK filtering failed.")
+        logger.error("SHARK filtering failed.")
         raise RuntimeError("SHARK filtering failed.")
 
     return filtered_fastq_1, filtered_fastq_2

--- a/vntyper/scripts/alignment_processing.py
+++ b/vntyper/scripts/alignment_processing.py
@@ -1,13 +1,15 @@
-#!/usr/bin/env python3
 # vntyper/scripts/alignment_processing.py
+
+from __future__ import annotations
 
 import importlib.resources as pkg_resources
 import json
 import logging
 from pathlib import Path
-from typing import Optional
 
 from vntyper.scripts.utils import run_command
+
+logger = logging.getLogger(__name__)
 
 
 def check_bwa_index(reference: Path) -> bool:
@@ -40,7 +42,7 @@ def check_bwa_index(reference: Path) -> bool:
 
     if missing_files:
         # Log a warning with the list of missing index files
-        logging.warning(f"Missing BWA index files for reference {reference}: {[str(f) for f in missing_files]}")
+        logger.warning(f"Missing BWA index files for reference {reference}: {[str(f) for f in missing_files]}")
         return False
     return True
 
@@ -53,7 +55,7 @@ def align_and_sort_fastq(
     output_name: str,
     threads: int,
     config: dict,
-) -> Optional[str]:
+) -> str | None:
     """
     Align FASTQ files to the reference genome using BWA, then sort and convert to BAM using Samtools.
 
@@ -79,7 +81,7 @@ def align_and_sort_fastq(
         samtools_path = Path(config["tools"]["samtools"])
         bwa_path = Path(config["tools"]["bwa"])
     except KeyError as e:
-        logging.error(f"Missing tool path in configuration: {e}")
+        logger.error(f"Missing tool path in configuration: {e}")
         return None
 
     output_dir = Path(output_dir)
@@ -88,7 +90,7 @@ def align_and_sort_fastq(
     sorted_bam_out = output_dir / f"{output_name}_sorted.bam"
 
     if not check_bwa_index(reference):
-        logging.error(
+        logger.error(
             f"BWA index files not found for reference: {reference}. "
             f"Please run 'bwa index {reference}' to generate them."
         )
@@ -103,32 +105,32 @@ def align_and_sort_fastq(
 
     full_command = f"{bwa_command} | {samtools_view_sort_command}"
     log_file_alignment = output_dir / f"{output_name}_alignment.log"
-    logging.info(f"Executing alignment and sorting with command: {full_command}")
+    logger.info(f"Executing alignment and sorting with command: {full_command}")
 
     if not run_command(str(full_command), str(log_file_alignment), critical=True):
-        logging.error("BWA alignment and Samtools sorting failed.")
+        logger.error("BWA alignment and Samtools sorting failed.")
         return None
 
     if not sorted_bam_out.exists():
-        logging.error(
+        logger.error(
             f"Sorted BAM file {sorted_bam_out} not created. BWA alignment or Samtools sorting might have failed."
         )
         return None
 
-    logging.info("BWA alignment and Samtools sorting completed successfully.")
+    logger.info("BWA alignment and Samtools sorting completed successfully.")
 
-    logging.info(f"Indexing sorted BAM file: {sorted_bam_out}")
+    logger.info(f"Indexing sorted BAM file: {sorted_bam_out}")
     samtools_index_command = f"{samtools_path} index {sorted_bam_out}"
     log_file_index = output_dir / f"{output_name}_index.log"
 
     if not run_command(str(samtools_index_command), str(log_file_index), critical=True):
-        logging.error("Samtools indexing failed.")
+        logger.error("Samtools indexing failed.")
         return None
 
     index_file = sorted_bam_out.with_suffix(".bam.bai")
     if not index_file.exists():
-        logging.error(f"BAM index file {index_file} not created. Samtools indexing might have failed.")
+        logger.error(f"BAM index file {index_file} not created. Samtools indexing might have failed.")
         return None
 
-    logging.info("Samtools indexing completed successfully.")
+    logger.info("Samtools indexing completed successfully.")
     return str(sorted_bam_out)

--- a/vntyper/scripts/chromosome_utils.py
+++ b/vntyper/scripts/chromosome_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 chromosome_utils.py
 
@@ -14,9 +13,12 @@ Functions:
     validate_chromosome_name: Validate that a chromosome name follows expected patterns
 """
 
+from __future__ import annotations
+
 import logging
 import re
-from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # Chr1 length constants for assembly detection (Phase 1 - Issue #139 fix)
 CHR1_LENGTHS = {
@@ -27,7 +29,7 @@ CHR1_LENGTHS = {
 }
 
 
-def detect_assembly_from_chr1_length(contigs: list[dict]) -> Optional[str]:
+def detect_assembly_from_chr1_length(contigs: list[dict]) -> str | None:
     """
     Detect reference assembly from chr1 length - most reliable method.
 
@@ -65,30 +67,30 @@ def detect_assembly_from_chr1_length(contigs: list[dict]) -> Optional[str]:
         - plan/02_active/2025-10-27_assembly-detection-fix/SENIOR_DEVELOPER_REVIEW.md
     """
     if not contigs:
-        logging.debug("Empty contigs list provided to detect_assembly_from_chr1_length")
+        logger.debug("Empty contigs list provided to detect_assembly_from_chr1_length")
         return None
 
     # Find chr1 (handles both UCSC "chr1" and ENSEMBL "1" naming, case-insensitive)
     chr1 = next((c for c in contigs if c.get("name", "").lower() in ["chr1", "1"]), None)
 
     if not chr1:
-        logging.debug("Chr1 not found in contigs (tried 'chr1' and '1')")
+        logger.debug("Chr1 not found in contigs (tried 'chr1' and '1')")
         return None
 
     chr1_length = chr1.get("length")
     if chr1_length is None:
-        logging.warning("Chr1 found but length is None")
+        logger.warning("Chr1 found but length is None")
         return None
 
-    logging.debug(f"Chr1 length: {chr1_length:,} bp")
+    logger.debug(f"Chr1 length: {chr1_length:,} bp")
 
     # Check against known assemblies (GRCh* prioritized over hg* aliases)
     for assembly in ["GRCh38", "hg38", "GRCh37", "hg19"]:
         if chr1_length == CHR1_LENGTHS[assembly]:
-            logging.info(f"Assembly detected from chr1 length: {assembly} ({chr1_length:,} bp)")
+            logger.info(f"Assembly detected from chr1 length: {assembly} ({chr1_length:,} bp)")
             return assembly
 
-    logging.warning(
+    logger.warning(
         f"Unknown chr1 length: {chr1_length:,} bp. "
         f"Expected GRCh38/hg38: {CHR1_LENGTHS['GRCh38']:,} bp or "
         f"GRCh37/hg19: {CHR1_LENGTHS['GRCh37']:,} bp"
@@ -120,7 +122,7 @@ def detect_naming_convention(contig_names: list[str]) -> str:
         'ncbi'
     """
     if not contig_names:
-        logging.warning("Empty contig list provided to detect_naming_convention")
+        logger.warning("Empty contig list provided to detect_naming_convention")
         return "unknown"
 
     # Count naming patterns
@@ -144,16 +146,16 @@ def detect_naming_convention(contig_names: list[str]) -> str:
     threshold = 0.5  # At least 50% of contigs should match the pattern
 
     if ucsc_count / total >= threshold:
-        logging.debug(f"Detected UCSC naming convention ({ucsc_count}/{total} contigs)")
+        logger.debug(f"Detected UCSC naming convention ({ucsc_count}/{total} contigs)")
         return "ucsc"
     elif ncbi_count / total >= threshold:
-        logging.debug(f"Detected NCBI naming convention ({ncbi_count}/{total} contigs)")
+        logger.debug(f"Detected NCBI naming convention ({ncbi_count}/{total} contigs)")
         return "ncbi"
     elif ensembl_count / total >= threshold:
-        logging.debug(f"Detected ENSEMBL naming convention ({ensembl_count}/{total} contigs)")
+        logger.debug(f"Detected ENSEMBL naming convention ({ensembl_count}/{total} contigs)")
         return "ensembl"
     else:
-        logging.warning(
+        logger.warning(
             f"Could not determine naming convention. UCSC: {ucsc_count}, ENSEMBL: {ensembl_count}, NCBI: {ncbi_count}"
         )
         return "unknown"
@@ -196,7 +198,7 @@ def get_chromosome_name_from_bam(
     try:
         header = extract_bam_header(bam_file, config)
     except Exception as e:
-        logging.error(f"Failed to extract BAM header from {bam_file}: {e}")
+        logger.error(f"Failed to extract BAM header from {bam_file}: {e}")
         raise ValueError(f"Cannot read BAM header: {e}") from e
 
     # Parse contigs
@@ -205,11 +207,11 @@ def get_chromosome_name_from_bam(
         raise ValueError(f"No contigs found in BAM header for {bam_file}")
 
     contig_names = [c["name"] for c in contigs]
-    logging.debug(f"Found {len(contig_names)} contigs in BAM header. First 5: {contig_names[:5]}")
+    logger.debug(f"Found {len(contig_names)} contigs in BAM header. First 5: {contig_names[:5]}")
 
     # Detect naming convention
     convention = detect_naming_convention(contig_names)
-    logging.debug(f"Detected naming convention: {convention}")
+    logger.debug(f"Detected naming convention: {convention}")
 
     # Build expected chromosome name based on convention
     chr_name = _build_chromosome_name(chromosome_number, convention, reference_assembly, config)
@@ -220,7 +222,7 @@ def get_chromosome_name_from_bam(
         chr_name_lower = chr_name.lower()
         for name in contig_names:
             if name.lower() == chr_name_lower:
-                logging.debug(f"Found case-insensitive match: {name} for {chr_name}")
+                logger.debug(f"Found case-insensitive match: {name} for {chr_name}")
                 return name
 
         # Chromosome not found - provide helpful error
@@ -230,7 +232,7 @@ def get_chromosome_name_from_bam(
             f"Available contigs: {', '.join(contig_names[:10])}..."
         )
 
-    logging.debug(f"Resolved chromosome {chromosome_number} to '{chr_name}'")
+    logger.debug(f"Resolved chromosome {chromosome_number} to '{chr_name}'")
     return chr_name
 
 
@@ -281,7 +283,7 @@ def _build_chromosome_name(chromosome_number: int, convention: str, reference_as
         try:
             coord_assembly = get_coordinate_system(reference_assembly)
         except ValueError:
-            logging.warning(f"Unknown assembly '{reference_assembly}', defaulting to GRCh37")
+            logger.warning(f"Unknown assembly '{reference_assembly}', defaulting to GRCh37")
             coord_assembly = "GRCh37"
 
         # Get NCBI accession from config
@@ -297,7 +299,7 @@ def _build_chromosome_name(chromosome_number: int, convention: str, reference_as
 
     else:
         # Unknown convention - return ENSEMBL simple numeric format as fallback
-        logging.warning(f"Unknown naming convention '{convention}', using ENSEMBL simple numeric format")
+        logger.warning(f"Unknown naming convention '{convention}', using ENSEMBL simple numeric format")
         return chr_suffix if chromosome_number >= 23 else str(chromosome_number)
 
 
@@ -429,5 +431,5 @@ def validate_chromosome_name(chromosome_name: str) -> bool:
         if re.match(pattern, chromosome_name, re.IGNORECASE):
             return True
 
-    logging.debug(f"Chromosome name '{chromosome_name}' did not match any pattern")
+    logger.debug(f"Chromosome name '{chromosome_name}' did not match any pattern")
     return False

--- a/vntyper/scripts/cohort_summary.py
+++ b/vntyper/scripts/cohort_summary.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 vntyper/scripts/cohort_summary.py
 
@@ -18,7 +17,7 @@ import os
 import shutil
 import tempfile
 import zipfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import matplotlib
@@ -27,6 +26,8 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.io as pio
 from jinja2 import Environment, FileSystemLoader
+
+logger = logging.getLogger(__name__)
 
 matplotlib.use("Agg")
 
@@ -50,7 +51,7 @@ def encode_image_to_base64(image_path):
             encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
         return f"data:image/png;base64,{encoded_string}"
     except Exception as e:
-        logging.error(f"Failed to encode image {image_path}: {e}")
+        logger.error(f"Failed to encode image {image_path}: {e}")
         return ""
 
 
@@ -84,7 +85,7 @@ def generate_donut_chart(values, labels, total, title, colors, plot_path=None, i
         Base64-encoded image string for static charts or HTML string for interactive charts.
     """
     if sum(values) == 0:
-        logging.warning(f"No data to plot for donut chart '{title}'.")
+        logger.warning(f"No data to plot for donut chart '{title}'.")
         return ""
     if interactive:
         fig = go.Figure(
@@ -92,7 +93,7 @@ def generate_donut_chart(values, labels, total, title, colors, plot_path=None, i
                 labels=labels,
                 values=values,
                 hole=0.6,
-                marker=dict(colors=colors, line=dict(color="black", width=2)),
+                marker={"colors": colors, "line": {"color": "black", "width": 2}},
                 textinfo="none",
             )
         )
@@ -104,9 +105,9 @@ def generate_donut_chart(values, labels, total, title, colors, plot_path=None, i
                 "xanchor": "center",
                 "yanchor": "top",
             },
-            annotations=[dict(text=f"<b>{total}</b>", x=0.5, y=0.5, font_size=40, showarrow=False)],
+            annotations=[{"text": f"<b>{total}</b>", "x": 0.5, "y": 0.5, "font_size": 40, "showarrow": False}],
             showlegend=False,
-            margin=dict(t=50, b=50, l=50, r=50),
+            margin={"t": 50, "b": 50, "l": 50, "r": 50},
             height=500,
             width=500,
         )
@@ -127,9 +128,9 @@ def generate_donut_chart(values, labels, total, title, colors, plot_path=None, i
             if plot_path:
                 plt.savefig(plot_path)
             else:
-                logging.warning("No plot_path provided for static donut chart, chart not saved.")
+                logger.warning("No plot_path provided for static donut chart, chart not saved.")
         except Exception as e:
-            logging.error(f"Error generating donut chart: {e}")
+            logger.error(f"Error generating donut chart: {e}")
         plt.close()
         if plot_path and os.path.exists(plot_path):
             return encode_image_to_base64(plot_path)
@@ -150,10 +151,10 @@ def load_report_config():
     try:
         with open(config_path) as f:
             report_config = json.load(f)
-        logging.info("Loaded report config from %s", config_path)
+        logger.info("Loaded report config from %s", config_path)
         return report_config
     except Exception as e:
-        logging.error("Failed to load report config: %s", e)
+        logger.error("Failed to load report config: %s", e)
         return {}
 
 
@@ -174,22 +175,22 @@ def compute_algorithm_result(df, logic_config):
         str: The computed algorithm result (e.g., 'High_Precision', 'positive', etc.).
     """
     if df.empty:
-        logging.debug("DataFrame is empty; returning default result.")
+        logger.debug("DataFrame is empty; returning default result.")
         return logic_config.get("default", "none")
     row = df.iloc[0]
-    logging.debug("Data row for evaluation: %s", row.to_dict())
-    logging.debug("Logic configuration: %s", logic_config)
+    logger.debug("Data row for evaluation: %s", row.to_dict())
+    logger.debug("Logic configuration: %s", logic_config)
     for idx, rule in enumerate(logic_config.get("rules", [])):
-        logging.debug("Evaluating rule %s: %s", idx, rule)
+        logger.debug("Evaluating rule %s: %s", idx, rule)
         conditions = rule.get("conditions", {})
         rule_matches = True
         for col, expected in conditions.items():
             if col not in row:
-                logging.debug("Rule %s: Column '%s' not found; rule fails.", idx, col)
+                logger.debug("Rule %s: Column '%s' not found; rule fails.", idx, col)
                 rule_matches = False
                 break
             actual = str(row.get(col, "")).strip()
-            logging.debug(
+            logger.debug(
                 "Rule %s, column '%s': actual='%s', expected='%s'",
                 idx,
                 col,
@@ -201,7 +202,7 @@ def compute_algorithm_result(df, logic_config):
                 exp_val = expected.get("value")
                 if op == "==":
                     if actual != str(exp_val).strip():
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s == %s' not met (actual='%s').",
                             idx,
                             col,
@@ -212,7 +213,7 @@ def compute_algorithm_result(df, logic_config):
                         break
                 elif op == "!=":
                     if actual == str(exp_val).strip():
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s != %s' not met (actual='%s').",
                             idx,
                             col,
@@ -225,7 +226,7 @@ def compute_algorithm_result(df, logic_config):
                     if not isinstance(exp_val, list):
                         exp_val = [exp_val]
                     if actual not in exp_val:
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s in %s' not met (actual='%s').",
                             idx,
                             col,
@@ -238,7 +239,7 @@ def compute_algorithm_result(df, logic_config):
                     if not isinstance(exp_val, list):
                         exp_val = [exp_val]
                     if actual in exp_val:
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s not in %s' not met (actual='%s').",
                             idx,
                             col,
@@ -248,7 +249,7 @@ def compute_algorithm_result(df, logic_config):
                         rule_matches = False
                         break
                 else:
-                    logging.debug(
+                    logger.debug(
                         "Rule %s: Unsupported operator '%s' for column '%s'.",
                         idx,
                         op,
@@ -259,7 +260,7 @@ def compute_algorithm_result(df, logic_config):
             else:
                 if isinstance(expected, list):
                     if actual not in expected:
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s in %s' not met (actual='%s').",
                             idx,
                             col,
@@ -270,7 +271,7 @@ def compute_algorithm_result(df, logic_config):
                         break
                 else:
                     if actual != str(expected):
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s == %s' not met (actual='%s').",
                             idx,
                             col,
@@ -281,11 +282,11 @@ def compute_algorithm_result(df, logic_config):
                         break
         if rule_matches:
             result = rule.get("result")
-            logging.debug("Rule %s PASSED; returning result: %s", idx, result)
+            logger.debug("Rule %s PASSED; returning result: %s", idx, result)
             return result
         else:
-            logging.debug("Rule %s did not pass.", idx)
-    logging.debug("No rule matched; returning default result.")
+            logger.debug("Rule %s did not pass.", idx)
+    logger.debug("No rule matched; returning default result.")
     return logic_config.get("default", "none")
 
 
@@ -363,7 +364,7 @@ def load_pipeline_summary_for_sample(sample_dir):
     sample_dir = Path(sample_dir)
     summary_path = sample_dir / "pipeline_summary.json"
     if not summary_path.exists():
-        logging.warning(f"Pipeline summary file not found in {sample_dir}")
+        logger.warning(f"Pipeline summary file not found in {sample_dir}")
         return [], [], {}
     try:
         with open(summary_path) as f:
@@ -407,7 +408,7 @@ def load_pipeline_summary_for_sample(sample_dir):
                     additional_stats["coverage"] = data_list[0]
         return kestrel_data, advntr_data, additional_stats
     except Exception as e:
-        logging.error(f"Error loading pipeline summary from {sample_dir}: {e}")
+        logger.error(f"Error loading pipeline summary from {sample_dir}: {e}")
         return [], [], {}
 
 
@@ -599,11 +600,11 @@ def generate_cohort_summary_report(output_dir, kestrel_df, advntr_df, summary_fi
     try:
         template = env.get_template("cohort_summary_template.html")
     except Exception as e:
-        logging.error(f"Failed to load Jinja2 template: {e}")
+        logger.error(f"Failed to load Jinja2 template: {e}")
         raise
 
     context = {
-        "report_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "report_date": datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S"),
         "kestrel_positive": kestrel_html,
         "advntr_positive": advntr_html,
         "kestrel_plot_base64": kestrel_plot_base64,
@@ -617,16 +618,16 @@ def generate_cohort_summary_report(output_dir, kestrel_df, advntr_df, summary_fi
     try:
         rendered_html = template.render(context)
     except Exception as e:
-        logging.error(f"Failed to render the cohort summary template: {e}")
+        logger.error(f"Failed to render the cohort summary template: {e}")
         raise
 
     report_file_path = Path(output_dir) / summary_file
     try:
         with open(report_file_path, "w") as f:
             f.write(rendered_html)
-        logging.info(f"Cohort summary report generated and saved to {report_file_path}")
+        logger.info(f"Cohort summary report generated and saved to {report_file_path}")
     except Exception as e:
-        logging.error(f"Failed to write the cohort summary report: {e}")
+        logger.error(f"Failed to write the cohort summary report: {e}")
         raise
 
 
@@ -684,52 +685,52 @@ def aggregate_cohort(
     for path_str in input_paths:
         path = Path(path_str)
         if not path.exists():
-            logging.warning(f"Input path does not exist and will be skipped: {path}")
+            logger.warning(f"Input path does not exist and will be skipped: {path}")
             continue
         if path.is_dir():
             if (path / "pipeline_summary.json").exists():
-                logging.info(f"Found pipeline_summary.json in {path}")
+                logger.info(f"Found pipeline_summary.json in {path}")
                 processed_dirs.add(path)
             else:
                 found = False
                 for summary_file_path in path.rglob("pipeline_summary.json"):
                     sample_dir = summary_file_path.parent
-                    logging.info(f"Found pipeline_summary.json in {sample_dir}")
+                    logger.info(f"Found pipeline_summary.json in {sample_dir}")
                     processed_dirs.add(sample_dir)
                     found = True
                 if not found:
-                    logging.warning(f"No pipeline_summary.json found in directory {path}")
+                    logger.warning(f"No pipeline_summary.json found in directory {path}")
         elif zipfile.is_zipfile(path):
-            logging.info(f"Extracting zip file: {path}")
+            logger.info(f"Extracting zip file: {path}")
             temp_dir = tempfile.mkdtemp(prefix="cohort_zip_")
             try:
                 with zipfile.ZipFile(path, "r") as zip_ref:
                     zip_ref.extractall(temp_dir)
                 temp_path = Path(temp_dir)
                 if (temp_path / "pipeline_summary.json").exists():
-                    logging.info(f"Found pipeline_summary.json in {temp_path}")
+                    logger.info(f"Found pipeline_summary.json in {temp_path}")
                     processed_dirs.add(temp_path)
                 else:
                     found = False
                     for summary_file_path in temp_path.rglob("pipeline_summary.json"):
                         sample_dir = summary_file_path.parent
-                        logging.info(f"Found pipeline_summary.json in {sample_dir}")
+                        logger.info(f"Found pipeline_summary.json in {sample_dir}")
                         processed_dirs.add(sample_dir)
                         found = True
                     if not found:
-                        logging.warning(f"No pipeline_summary.json found in extracted zip file: {path}")
+                        logger.warning(f"No pipeline_summary.json found in extracted zip file: {path}")
                 temp_dirs.append(temp_dir)
             except zipfile.BadZipFile as e:
-                logging.error(f"Bad zip file {path}: {e}")
+                logger.error(f"Bad zip file {path}: {e}")
                 shutil.rmtree(temp_dir)
             except Exception as e:
-                logging.error(f"Error extracting zip file {path}: {e}")
+                logger.error(f"Error extracting zip file {path}: {e}")
                 shutil.rmtree(temp_dir)
         else:
-            logging.warning(f"Unsupported file type (not a directory or zip): {path}")
+            logger.warning(f"Unsupported file type (not a directory or zip): {path}")
 
     if not processed_dirs:
-        logging.error("No valid input directories or zip files found for cohort aggregation.")
+        logger.error("No valid input directories or zip files found for cohort aggregation.")
         return
 
     # If pseudonymization is requested, build a mapping from original to pseudonym names.
@@ -747,20 +748,20 @@ def aggregate_cohort(
         else:
             pseudonym = original_sample
 
-        logging.info(f"Processing sample directory: {sample_dir} as {pseudonym}")
+        logger.info(f"Processing sample directory: {sample_dir} as {pseudonym}")
         k_data, a_data, add_stats = load_pipeline_summary_for_sample(sample_dir)
         if k_data:
             for entry in k_data:
                 entry["Sample"] = pseudonym
             kestrel_list.extend(k_data)
         else:
-            logging.warning(f"No Kestrel data found in pipeline summary for sample {original_sample}.")
+            logger.warning(f"No Kestrel data found in pipeline summary for sample {original_sample}.")
         if a_data:
             for entry in a_data:
                 entry["Sample"] = pseudonym
             advntr_list.extend(a_data)
         else:
-            logging.warning(f"No adVNTR data found in pipeline summary for sample {original_sample}.")
+            logger.warning(f"No adVNTR data found in pipeline summary for sample {original_sample}.")
         if add_stats:
             add_stats["Sample"] = pseudonym
             additional_stats_list.append(add_stats)
@@ -768,12 +769,12 @@ def aggregate_cohort(
     if kestrel_list:
         kestrel_df = pd.DataFrame(kestrel_list)
     else:
-        logging.warning("No Kestrel data found in any sample.")
+        logger.warning("No Kestrel data found in any sample.")
         kestrel_df = pd.DataFrame()
     if advntr_list:
         advntr_df = pd.DataFrame(advntr_list)
     else:
-        logging.warning("No adVNTR data found in any sample.")
+        logger.warning("No adVNTR data found in any sample.")
         advntr_df = pd.DataFrame()
 
     # Create additional statistics DataFrame and HTML table if any stats were gathered.
@@ -808,9 +809,9 @@ def aggregate_cohort(
     for temp_dir in temp_dirs:
         try:
             shutil.rmtree(temp_dir)
-            logging.debug(f"Cleaned up temporary directory: {temp_dir}")
+            logger.debug(f"Cleaned up temporary directory: {temp_dir}")
         except Exception as e:
-            logging.error(f"Failed to remove temporary directory {temp_dir}: {e}")
+            logger.error(f"Failed to remove temporary directory {temp_dir}: {e}")
 
     # Generate additional machine-readable cohort summaries if requested
     if additional_formats:
@@ -819,28 +820,28 @@ def aggregate_cohort(
             if "csv" in formats:
                 csv_path = Path(output_dir) / "cohort_kestrel.csv"
                 kestrel_df.to_csv(csv_path, index=False)
-                logging.info(f"Cohort Kestrel CSV written to: {csv_path}")
+                logger.info(f"Cohort Kestrel CSV written to: {csv_path}")
             if "tsv" in formats:
                 tsv_path = Path(output_dir) / "cohort_kestrel.tsv"
                 kestrel_df.to_csv(tsv_path, sep="\t", index=False)
-                logging.info(f"Cohort Kestrel TSV written to: {tsv_path}")
+                logger.info(f"Cohort Kestrel TSV written to: {tsv_path}")
             if "json" in formats:
                 json_path = Path(output_dir) / "cohort_kestrel.json"
                 kestrel_df.to_json(json_path, orient="records", indent=4)
-                logging.info(f"Cohort Kestrel JSON written to: {json_path}")
+                logger.info(f"Cohort Kestrel JSON written to: {json_path}")
         if not advntr_df.empty:
             if "csv" in formats:
                 csv_path = Path(output_dir) / "cohort_advntr.csv"
                 advntr_df.to_csv(csv_path, index=False)
-                logging.info(f"Cohort adVNTR CSV written to: {csv_path}")
+                logger.info(f"Cohort adVNTR CSV written to: {csv_path}")
             if "tsv" in formats:
                 tsv_path = Path(output_dir) / "cohort_advntr.tsv"
                 advntr_df.to_csv(tsv_path, sep="\t", index=False)
-                logging.info(f"Cohort adVNTR TSV written to: {tsv_path}")
+                logger.info(f"Cohort adVNTR TSV written to: {tsv_path}")
             if "json" in formats:
                 json_path = Path(output_dir) / "cohort_advntr.json"
                 advntr_df.to_json(json_path, orient="records", indent=4)
-                logging.info(f"Cohort adVNTR JSON written to: {json_path}")
+                logger.info(f"Cohort adVNTR JSON written to: {json_path}")
 
     # If pseudonymization was enabled, output the pseudonymization table.
     if pseudonymize_samples and sample_mapping:
@@ -850,6 +851,6 @@ def aggregate_cohort(
                 pt.write("Pseudonym\tOriginal\n")
                 for pseudonym, original in sample_mapping.items():
                     pt.write(f"{pseudonym}\t{original}\n")
-            logging.info(f"Pseudonymization table written to: {pseudonym_table_path}")
+            logger.info(f"Pseudonymization table written to: {pseudonym_table_path}")
         except Exception as e:
-            logging.error(f"Failed to write pseudonymization table: {e}")
+            logger.error(f"Failed to write pseudonymization table: {e}")

--- a/vntyper/scripts/confidence_assignment.py
+++ b/vntyper/scripts/confidence_assignment.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 confidence_assignment.py
 
@@ -27,6 +26,8 @@ import logging
 
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 # Confidence label for variants that fail depth-based filtering.
 # Used as the default and for Depth_Score below the configured low_threshold.
@@ -67,11 +68,11 @@ def calculate_depth_score_and_assign_confidence(df: pd.DataFrame, kestrel_config
               - 'Confidence' (str, e.g., 'Low_Precision', 'High_Precision', etc.)
               - 'depth_confidence_pass' (bool; True if Confidence != 'Negative')
     """
-    logging.debug("Entering calculate_depth_score_and_assign_confidence")
-    logging.debug(f"Initial DataFrame shape: {df.shape}")
+    logger.debug("Entering calculate_depth_score_and_assign_confidence")
+    logger.debug(f"Initial DataFrame shape: {df.shape}")
 
     if df.empty:
-        logging.debug("DataFrame is empty. Exiting function without changes.")
+        logger.debug("DataFrame is empty. Exiting function without changes.")
         return df
 
     # Extract relevant config subdict
@@ -155,6 +156,6 @@ def calculate_depth_score_and_assign_confidence(df: pd.DataFrame, kestrel_config
     # Step 4: Mark pass/fail: Passing means Confidence != NEGATIVE_LABEL
     df["depth_confidence_pass"] = df["Confidence"] != NEGATIVE_LABEL
 
-    logging.debug("Exiting calculate_depth_score_and_assign_confidence")
-    logging.debug(f"Final DataFrame shape: {df.shape}")
+    logger.debug("Exiting calculate_depth_score_and_assign_confidence")
+    logger.debug(f"Final DataFrame shape: {df.shape}")
     return df

--- a/vntyper/scripts/cross_match.py
+++ b/vntyper/scripts/cross_match.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 vntyper/scripts/cross_match.py
 
@@ -16,6 +15,8 @@ It accepts already‑parsed results (e.g. from a pipeline summary) without re‑
 
 import csv
 import logging
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MATCH_LOGIC = (
     "Kestrel_Allele_Change == Advntr_Allele_Change and Kestrel_Variant_Type.lower() == Advntr_Variant_Type.lower()"
@@ -130,7 +131,7 @@ def cross_match_variants(kestrel_records, advntr_records, config=None):
                 # Evaluate the matching condition in a restricted namespace.
                 match = bool(eval(match_logic, {"__builtins__": {}}, result))
             except Exception as e:
-                logging.error(f"Error evaluating match logic: {e}")
+                logger.error(f"Error evaluating match logic: {e}")
                 match = False
             result["Match"] = "Yes" if match else "No"
             if match:
@@ -150,7 +151,7 @@ def write_results_tsv(results, output_path):
         output_path (str or Path): File path to write the TSV.
     """
     if not results:
-        logging.info("No results to write.")
+        logger.info("No results to write.")
         return
     fieldnames = list(results[0].keys())
     with open(output_path, "w", newline="", encoding="utf-8") as out_f:

--- a/vntyper/scripts/extract_unmapped_from_offset.py
+++ b/vntyper/scripts/extract_unmapped_from_offset.py
@@ -10,6 +10,8 @@ import os
 
 import pysam
 
+logger = logging.getLogger(__name__)
+
 
 def read_uint32(f):
     """
@@ -44,8 +46,7 @@ def get_last_chunk_end(bai_filename):
                     # Each chunk: 8 bytes for chunk_beg, 8 bytes for chunk_end
                     _chunk_beg = read_uint64(bai)
                     chunk_end = read_uint64(bai)
-                    if chunk_end > max_vo:
-                        max_vo = chunk_end
+                    max_vo = max(max_vo, chunk_end)
             # Read number of linear index entries and skip them
             n_intv = read_uint32(bai)
             bai.seek(n_intv * 8, os.SEEK_CUR)
@@ -66,7 +67,7 @@ def extract_unmapped_reads_from_offset(bam_file, bai_file, output_bam):
         IOError: If reading/writing from disk fails, or if the BAI file is invalid.
     """
     last_vo = get_last_chunk_end(bai_file)
-    logging.info(f"Last mapped virtual offset (from BAI): {last_vo}")
+    logger.info(f"Last mapped virtual offset (from BAI): {last_vo}")
 
     with pysam.AlignmentFile(bam_file, "rb") as inbam:
         # Seek to the computed virtual offset.
@@ -77,4 +78,4 @@ def extract_unmapped_reads_from_offset(bam_file, bai_file, output_bam):
                 if read.is_unmapped:
                     outbam.write(read)
                     count += 1
-            logging.info(f"Extracted {count} unmapped reads to {output_bam}")
+            logger.info(f"Extracted {count} unmapped reads to {output_bam}")

--- a/vntyper/scripts/fastq_bam_processing.py
+++ b/vntyper/scripts/fastq_bam_processing.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python3
 # vntyper/scripts/fastq_bam_processing.py
+
+from __future__ import annotations
 
 import json
 import logging
@@ -7,13 +8,14 @@ import os
 import statistics  # for median and stdev calculations
 import subprocess
 from pathlib import Path
-from typing import Optional, Union
 
 from vntyper.scripts.extract_unmapped_from_offset import (
     extract_unmapped_reads_from_offset,
 )
 from vntyper.scripts.region_utils import get_region_string_with_fallback
 from vntyper.scripts.utils import run_command
+
+logger = logging.getLogger(__name__)
 
 
 def process_fastq(fastq_1, fastq_2, threads, output, output_name, config):
@@ -56,14 +58,14 @@ def process_fastq(fastq_1, fastq_2, threads, output, output_name, config):
         qc_command += " --dedup"
 
     log_file = Path(output) / f"{output_name}_fastp.log"
-    logging.info(f"Executing FASTQ quality control with command: {qc_command}")
+    logger.info(f"Executing FASTQ quality control with command: {qc_command}")
 
     success = run_command(str(qc_command), str(log_file), critical=True)
     if not success:
-        logging.error("FASTQ quality control failed.")
+        logger.error("FASTQ quality control failed.")
         raise RuntimeError("FASTQ quality control failed.")
 
-    logging.info("Quality control passed for FASTQ files.")
+    logger.info("Quality control passed for FASTQ files.")
 
 
 def process_bam_to_fastq(
@@ -110,23 +112,23 @@ def process_bam_to_fastq(
 
     if bed_file:
         if not bed_file.exists():
-            logging.error(f"Provided BED file does not exist: {bed_file}")
+            logger.error(f"Provided BED file does not exist: {bed_file}")
             raise FileNotFoundError(f"BED file not found: {bed_file}")
         bam_region = f"-L {bed_file}"
-        logging.debug(f"BAM regions set using BED file: {bam_region}")
+        logger.debug(f"BAM regions set using BED file: {bam_region}")
     else:
         # Use dynamic region resolution with fallback to legacy format
         bam_region = get_region_string_with_fallback(
             bam_file=str(in_bam), reference_assembly=reference_assembly, region_type="bam_region", config=config
         )
-        logging.debug(f"BAM region set to: {bam_region}")
+        logger.debug(f"BAM region set to: {bam_region}")
 
     cram_ref_option = ""
     final_bam = Path(output) / f"{output_name}_sliced.bam"
 
     # Slice/region extraction
     if keep_intermediates and final_bam.exists():
-        logging.info(f"Reusing existing BAM slice: {final_bam}")
+        logger.info(f"Reusing existing BAM slice: {final_bam}")
     else:
         if bed_file:
             command_slice = (
@@ -139,13 +141,13 @@ def process_bam_to_fastq(
                 f"{samtools_path} index {final_bam}"
             )
         log_file_slice = Path(output) / f"{output_name}_slice.log"
-        logging.info(f"Executing region slicing with command: {command_slice}")
+        logger.info(f"Executing region slicing with command: {command_slice}")
 
         success = run_command(str(command_slice), str(log_file_slice), critical=True)
         if not success:
-            logging.error(f"{file_format.upper()} region slicing failed.")
+            logger.error(f"{file_format.upper()} region slicing failed.")
             raise RuntimeError(f"{file_format.upper()} region slicing failed.")
-        logging.info("BAM/CRAM region slicing completed.")
+        logger.info("BAM/CRAM region slicing completed.")
 
     # Extract & merge unmapped reads if not in fast_mode
     if not fast_mode:
@@ -158,12 +160,12 @@ def process_bam_to_fastq(
                 # Index if not present
                 index_cmd = f"{samtools_path} index {in_bam}"
                 log_file_index = Path(output) / f"{output_name}_unmapped_index.log"
-                logging.info(f"Indexing BAM before extracting unmapped: {index_cmd}")
+                logger.info(f"Indexing BAM before extracting unmapped: {index_cmd}")
                 success = run_command(str(index_cmd), str(log_file_index), critical=True)
                 if not success:
                     raise RuntimeError("Indexing BAM file failed.")
 
-            logging.info("Extracting unmapped reads using offset calculation...")
+            logger.info("Extracting unmapped reads using offset calculation...")
             extract_unmapped_reads_from_offset(
                 bam_file=str(in_bam),
                 bai_file=str(bam_bai),
@@ -177,38 +179,38 @@ def process_bam_to_fastq(
                 f"> /dev/null"
             )
             log_file_filter = Path(output) / f"{output_name}_filter.log"
-            logging.info(f"Executing filtering with command: {command_filter}")
+            logger.info(f"Executing filtering with command: {command_filter}")
 
             success = run_command(str(command_filter), str(log_file_filter), critical=True)
             if not success:
-                logging.error("BAM/CRAM filtering failed.")
+                logger.error("BAM/CRAM filtering failed.")
                 raise RuntimeError("BAM/CRAM filtering failed.")
 
         # Merge sliced + unmapped
         merged_bam = Path(output) / f"{output_name}_sliced_unmapped.bam"
         command_merge = f"{samtools_path} merge -f -@ {threads} {merged_bam} {final_bam} {unmapped_bam}"
         log_file_merge = Path(output) / f"{output_name}_merge.log"
-        logging.info(f"Executing BAM merging with command: {command_merge}")
+        logger.info(f"Executing BAM merging with command: {command_merge}")
 
         success = run_command(str(command_merge), str(log_file_merge), critical=True)
         if not success:
-            logging.error("BAM merging failed.")
+            logger.error("BAM merging failed.")
             raise RuntimeError("BAM merging failed.")
 
         final_bam = merged_bam
-        logging.info("BAM/CRAM filtering and merging completed.")
+        logger.info("BAM/CRAM filtering and merging completed.")
 
         # Rename merged BAM for adVNTR consistency and re-index
         final_bam_renamed = Path(output) / f"{output_name}_sliced.bam"
         os.replace(final_bam, final_bam_renamed)
         final_bam = final_bam_renamed
-        logging.info(f"Renamed merged BAM file to {final_bam}")
+        logger.info(f"Renamed merged BAM file to {final_bam}")
 
         command_index = f"{samtools_path} index {final_bam}"
         log_file_index = Path(output) / f"{output_name}_index.log"
-        logging.info(f"Re-indexing BAM file with command: {command_index}")
+        logger.info(f"Re-indexing BAM file with command: {command_index}")
         if not run_command(command_index, str(log_file_index), critical=True):
-            logging.error("Re-indexing BAM file failed.")
+            logger.error("Re-indexing BAM file failed.")
             raise RuntimeError("Re-indexing BAM file failed.")
 
     # Convert final BAM to FASTQ
@@ -226,7 +228,7 @@ def process_bam_to_fastq(
             final_fastq_single,
         ]
     ):
-        logging.info(
+        logger.info(
             f"Reusing existing FASTQ files: {final_fastq_1}, {final_fastq_2}, "
             f"{final_fastq_other}, and {final_fastq_single}"
         )
@@ -238,25 +240,25 @@ def process_bam_to_fastq(
             f"-s {final_fastq_single}"
         )
         log_file_sort_fastq = Path(output) / f"{output_name}_sort_fastq.log"
-        logging.info(f"Executing BAM to FASTQ conversion with command: {command_sort_fastq}")
+        logger.info(f"Executing BAM to FASTQ conversion with command: {command_sort_fastq}")
 
         success = run_command(str(command_sort_fastq), str(log_file_sort_fastq), critical=True)
         if not success:
-            logging.error("BAM to FASTQ conversion failed.")
+            logger.error("BAM to FASTQ conversion failed.")
             raise RuntimeError("BAM to FASTQ conversion failed.")
-        logging.info("BAM to FASTQ conversion completed.")
+        logger.info("BAM to FASTQ conversion completed.")
 
     # Clean up intermediates if requested
     if delete_intermediates and not keep_intermediates:
-        logging.info("Removing intermediate BAM files...")
+        logger.info("Removing intermediate BAM files...")
         intermediate_files = [
             Path(output) / f"{output_name}_unmapped.bam",
         ]
         for file in intermediate_files:
             if file.exists():
                 file.unlink()
-                logging.debug(f"Removed intermediate file: {file}")
-        logging.info("Intermediate BAM files removed.")
+                logger.debug(f"Removed intermediate file: {file}")
+        logger.info("Intermediate BAM files removed.")
 
     return (
         str(final_fastq_1),
@@ -290,14 +292,14 @@ def calculate_vntr_coverage(bam_file, region, threads, config, output_dir, outpu
     samtools_path = config["tools"]["samtools"]
     coverage_output = Path(output_dir) / f"{output_name}_vntr_coverage.txt"
     depth_command = f"{samtools_path} depth -@ {threads} -r {region} {bam_file} > {coverage_output}"
-    logging.info(f"Calculating VNTR coverage with command: {depth_command}")
+    logger.info(f"Calculating VNTR coverage with command: {depth_command}")
     success = run_command(
         str(depth_command),
         str(coverage_output.with_suffix(".depth.log")),
         critical=True,
     )
     if not success:
-        logging.error("VNTR coverage calculation failed.")
+        logger.error("VNTR coverage calculation failed.")
         raise RuntimeError("VNTR coverage calculation failed.")
 
     try:
@@ -315,9 +317,9 @@ def calculate_vntr_coverage(bam_file, region, threads, config, output_dir, outpu
             start_pos = int(pos_range[0])
             end_pos = int(pos_range[1])
             total_region_length = end_pos - start_pos + 1
-            logging.debug(f"VNTR region total length: {total_region_length} bp")
+            logger.debug(f"VNTR region total length: {total_region_length} bp")
         except (ValueError, IndexError) as e:
-            logging.warning(f"Could not parse region string: {e}. Setting region length to 0.")
+            logger.warning(f"Could not parse region string: {e}. Setting region length to 0.")
             total_region_length = 0
 
         with open(coverage_output) as f:
@@ -338,14 +340,14 @@ def calculate_vntr_coverage(bam_file, region, threads, config, output_dir, outpu
         min_coverage = min(coverage_values)
         max_coverage = max(coverage_values)
 
-        logging.info(f"Mean VNTR coverage: {mean_coverage:.2f}")
-        logging.info(f"Median VNTR coverage: {median_coverage:.2f}")
-        logging.info(f"Standard deviation: {stdev_coverage:.2f}")
-        logging.info(f"Min coverage: {min_coverage}")
-        logging.info(f"Max coverage: {max_coverage}")
-        logging.info(f"VNTR region total length: {total_region_length} bp")
-        logging.info(f"VNTR region uncovered bases: {zero_coverage_bases} bp")
-        logging.info(f"Percentage of VNTR region with zero coverage: {percent_uncovered:.2f}%")
+        logger.info(f"Mean VNTR coverage: {mean_coverage:.2f}")
+        logger.info(f"Median VNTR coverage: {median_coverage:.2f}")
+        logger.info(f"Standard deviation: {stdev_coverage:.2f}")
+        logger.info(f"Min coverage: {min_coverage}")
+        logger.info(f"Max coverage: {max_coverage}")
+        logger.info(f"VNTR region total length: {total_region_length} bp")
+        logger.info(f"VNTR region uncovered bases: {zero_coverage_bases} bp")
+        logger.info(f"Percentage of VNTR region with zero coverage: {percent_uncovered:.2f}%")
 
         if summary_filename is None:
             summary_filename = Path(output_dir) / f"{output_name}_summary.tsv"
@@ -359,7 +361,7 @@ def calculate_vntr_coverage(bam_file, region, threads, config, output_dir, outpu
                 f"{min_coverage}\t{max_coverage}\t{total_region_length}\t"
                 f"{zero_coverage_bases}\t{percent_uncovered:.2f}\n"
             )
-        logging.info(f"Coverage summary written to: {summary_filename}")
+        logger.info(f"Coverage summary written to: {summary_filename}")
 
         return {
             "mean": mean_coverage,
@@ -372,7 +374,7 @@ def calculate_vntr_coverage(bam_file, region, threads, config, output_dir, outpu
             "percent_uncovered": percent_uncovered,
         }
     except Exception as e:
-        logging.error(f"Error calculating coverage summary: {e}")
+        logger.error(f"Error calculating coverage summary: {e}")
         raise RuntimeError(f"Error calculating coverage summary: {e}") from e
 
 
@@ -421,13 +423,13 @@ def downsample_bam_if_needed(
     )["mean"]
 
     if current_coverage <= max_coverage:
-        logging.info(
+        logger.info(
             f"Current coverage ({current_coverage:.2f}) <= max_coverage ({max_coverage}). No downsampling needed."
         )
         return bam_path
 
     fraction = max_coverage / current_coverage
-    logging.info(
+    logger.info(
         f"Current coverage: {current_coverage:.2f}, max coverage: {max_coverage}, downsampling fraction: {fraction:.4f}"
     )
 
@@ -448,11 +450,11 @@ def downsample_bam_if_needed(
         str(downsampled_bam),
         str(bam_path),
     ]
-    logging.info(f"Downsampling BAM with command: {' '.join(cmd_view)}")
+    logger.info(f"Downsampling BAM with command: {' '.join(cmd_view)}")
     try:
         subprocess.run(cmd_view, check=True)
     except subprocess.CalledProcessError as err:
-        logging.error(f"Downsampling failed: {err}")
+        logger.error(f"Downsampling failed: {err}")
         return bam_path
 
     sorted_down_bam = downsampled_bam.with_suffix(".sorted.bam")
@@ -471,10 +473,10 @@ def downsample_bam_if_needed(
         cmd_index = [samtools_path, "index", str(sorted_down_bam)]
         subprocess.run(cmd_index, check=True)
     except subprocess.CalledProcessError as err:
-        logging.error(f"Sorting/indexing failed after downsampling: {err}")
+        logger.error(f"Sorting/indexing failed after downsampling: {err}")
         return bam_path
 
-    logging.info(f"Downsampling complete. Using BAM: {sorted_down_bam}")
+    logger.info(f"Downsampling complete. Using BAM: {sorted_down_bam}")
     return sorted_down_bam
 
 
@@ -487,7 +489,7 @@ def parse_contigs_from_header(header: str) -> list:
     for line in header.splitlines():
         if line.startswith("@SQ"):
             parts = line.split("\t")
-            contig_info: dict[str, Union[str, int, None]] = {}
+            contig_info: dict[str, str | int | None] = {}
             for part in parts:
                 if part.startswith("SN:"):
                     contig_info["name"] = part.replace("SN:", "")
@@ -501,7 +503,7 @@ def parse_contigs_from_header(header: str) -> list:
     return contigs
 
 
-def detect_assembly_from_contigs(header: str, config: dict, threshold: Optional[float] = None) -> str:
+def detect_assembly_from_contigs(header: str, config: dict, threshold: float | None = None) -> str:
     """
     Detects the reference genome assembly by comparing contig information from the BAM header
     against known assemblies from config. Returns the detected assembly name if the match percentage
@@ -524,11 +526,11 @@ def detect_assembly_from_contigs(header: str, config: dict, threshold: Optional[
         threshold = assembly_config.get("detection_threshold", 0.9)
 
     if not known_assemblies:
-        logging.warning("No known_assemblies found in config. Assembly detection disabled.")
+        logger.warning("No known_assemblies found in config. Assembly detection disabled.")
         return "Not detected"
 
     bam_contigs = parse_contigs_from_header(header)
-    for _assembly_key, assembly_data in known_assemblies.items():
+    for assembly_data in known_assemblies.values():
         expected_contigs = assembly_data["contigs"]
         match_count = 0
         for expected in expected_contigs:
@@ -585,19 +587,19 @@ def parse_header_pipeline_info(
             "WARNING: The Dragen pipeline has known issues aligning reads in the VNTR region. "
             "It is recommended to use normal mode."
         )
-        logging.warning(warning_message)
+        logger.warning(warning_message)
     elif pipeline.lower() == "clc":
         warning_message = (
             "WARNING: The CLC pipeline may have issues aligning reads in the VNTR region (Not tested). "
             "It is recommended to use normal mode and verify results carefully."
         )
-        logging.warning(warning_message)
+        logger.warning(warning_message)
     elif pipeline.lower() == "unknown":
         warning_message = (
             "WARNING: Alignment pipeline could not be detected from the header. "
             "It is recommended to use the BWA aligner."
         )
-        logging.warning(warning_message)
+        logger.warning(warning_message)
 
     result = {
         "assembly_text": assembly_text,
@@ -611,10 +613,10 @@ def parse_header_pipeline_info(
     try:
         with open(output_path, "w", encoding="utf-8") as out_f:
             json.dump(result, out_f, indent=4)
-        logging.info(f"Pipeline info written to {output_path}")
+        logger.info(f"Pipeline info written to {output_path}")
     except Exception as e:
-        logging.error(f"Failed to write pipeline info file: {e}")
-        raise e
+        logger.error(f"Failed to write pipeline info file: {e}")
+        raise
 
 
 def extract_bam_header(bam_file: str, config: dict) -> str:

--- a/vntyper/scripts/file_processing.py
+++ b/vntyper/scripts/file_processing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/scripts/file_processing.py
 
 import importlib.resources as pkg_resources
@@ -22,7 +21,7 @@ def filter_vcf(input_path, output_path):
 
     with open(input_path) as vcf_file, open(output_path, "w") as indel_file:
         for line in vcf_file:
-            if line.startswith("##") or line.startswith("#CHROM"):
+            if line.startswith(("##", "#CHROM")):
                 indel_file.write(line)
             else:
                 _, _, _, ref, alt, *_ = line.split("\t")
@@ -52,7 +51,7 @@ def filter_indel_vcf(indel_vcf, output_ins, output_del):
 
     with open(indel_vcf) as vcf_file, open(output_ins, "w") as insertion_file, open(output_del, "w") as deletion_file:
         for line in vcf_file:
-            if line.startswith("##") or line.startswith("#CHROM"):
+            if line.startswith(("##", "#CHROM")):
                 insertion_file.write(line)
                 deletion_file.write(line)
             else:

--- a/vntyper/scripts/flagging.py
+++ b/vntyper/scripts/flagging.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 flagging.py
 
@@ -17,11 +16,14 @@ Example flagging rule:
 }
 """
 
+from __future__ import annotations
+
 import logging
 import re
-from typing import Optional
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def regex_match(pattern, value):
@@ -38,7 +40,7 @@ def regex_match(pattern, value):
     try:
         return bool(re.search(pattern, str(value)))
     except Exception as e:
-        logging.error(f"Error in regex_match with pattern {pattern} and value {value}: {e}")
+        logger.error(f"Error in regex_match with pattern {pattern} and value {value}: {e}")
         return False
 
 
@@ -80,14 +82,14 @@ def evaluate_condition(row, condition):
         result = eval(condition, {"__builtins__": {}}, local_vars)
         return bool(result)
     except NameError as ne:
-        logging.warning(f"NameError while evaluating condition '{condition}' with row {row.to_dict()}: {ne}")
+        logger.warning(f"NameError while evaluating condition '{condition}' with row {row.to_dict()}: {ne}")
         return False
     except Exception as e:
-        logging.error(f"Error evaluating condition '{condition}' with row {row.to_dict()}: {e}")
+        logger.error(f"Error evaluating condition '{condition}' with row {row.to_dict()}: {e}")
         return False
 
 
-def add_flags(df: pd.DataFrame, flag_rules: dict, duplicates_config: Optional[dict] = None) -> pd.DataFrame:
+def add_flags(df: pd.DataFrame, flag_rules: dict, duplicates_config: dict | None = None) -> pd.DataFrame:
     """
     Applies flagging rules to the DataFrame and adds a 'Flag' column with the matched flags.
 
@@ -122,31 +124,31 @@ def add_flags(df: pd.DataFrame, flag_rules: dict, duplicates_config: Optional[di
     """
     # Create a copy to avoid modifying the original DataFrame
     df_copy = df.copy()
-    logging.debug("Created a copy of the DataFrame for flag processing.")
+    logger.debug("Created a copy of the DataFrame for flag processing.")
 
     # Initialize a list to store flags for each row
     flags: list[list[str]] = [[] for _ in range(len(df_copy))]
-    logging.debug("Initialized flags list for each row.")
+    logger.debug("Initialized flags list for each row.")
 
     # Evaluate each flag rule
     for flag, condition in flag_rules.items():
-        logging.debug(f"Evaluating flag rule '{flag}': {condition}")
+        logger.debug(f"Evaluating flag rule '{flag}': {condition}")
         mask = df_copy.apply(lambda row, cond=condition: evaluate_condition(row, cond), axis=1)
         matching_count = mask.sum()
-        logging.debug(f"Flag rule '{flag}' matched {matching_count} rows.")
+        logger.debug(f"Flag rule '{flag}' matched {matching_count} rows.")
         for i, condition_met in enumerate(mask):
             if condition_met:
                 flags[i].append(flag)
-                logging.debug(f"Row {i} meets condition for flag '{flag}'.")
+                logger.debug(f"Row {i} meets condition for flag '{flag}'.")
 
     # Create the 'Flag' column as a comma-separated string of flags for each row,
     # or 'Not flagged' if no flags were applied.
     df_copy["Flag"] = [", ".join(flag_list) if flag_list else "Not flagged" for flag_list in flags]
-    logging.debug("Added 'Flag' column to DataFrame with flag values.")
+    logger.debug("Added 'Flag' column to DataFrame with flag values.")
 
     # Mark potential duplicates if configured
     if duplicates_config and duplicates_config.get("enabled", False):
-        logging.debug(f"Duplicates config detected: {duplicates_config}")
+        logger.debug(f"Duplicates config detected: {duplicates_config}")
         group_cols = duplicates_config.get("group_by", ["REF", "ALT"])
         sort_info = duplicates_config.get("sort_by", [])
         if not sort_info:
@@ -157,7 +159,7 @@ def add_flags(df: pd.DataFrame, flag_rules: dict, duplicates_config: Optional[di
             sort_cols = [item["column"] for item in sort_info]
             sort_ascending = [item["ascending"] for item in sort_info]
 
-        logging.debug(
+        logger.debug(
             "Calling mark_potential_duplicates with "
             f"group_cols={group_cols}, sort_cols={sort_cols}, sort_ascending={sort_ascending}"
         )
@@ -169,7 +171,7 @@ def add_flags(df: pd.DataFrame, flag_rules: dict, duplicates_config: Optional[di
             duplicate_flag_name=duplicates_config.get("flag_name", "Potential_Duplicate"),
         )
     else:
-        logging.debug("No duplicates_config or 'enabled' is False; skipping duplicate flagging.")
+        logger.debug("No duplicates_config or 'enabled' is False; skipping duplicate flagging.")
 
     return df_copy
 
@@ -201,7 +203,7 @@ def mark_potential_duplicates(
         pd.DataFrame: A copy of the input DataFrame with duplicate rows flagged in the 'Flag' column.
     """
     df_copy = df.copy()
-    logging.debug(
+    logger.debug(
         f"Marking potential duplicates with group_cols={group_cols}, "
         f"sort_cols={sort_cols}, sort_ascending={sort_ascending}, "
         f"duplicate_flag_name={duplicate_flag_name}"
@@ -209,11 +211,11 @@ def mark_potential_duplicates(
 
     # Keep track of original index to restore ordering after grouping/sorting
     df_copy["__original_index"] = df_copy.index
-    logging.debug(f"DataFrame shape before sorting: {df_copy.shape}")
+    logger.debug(f"DataFrame shape before sorting: {df_copy.shape}")
 
     # Sort by the specified columns and order
     df_copy.sort_values(by=sort_cols, ascending=sort_ascending, inplace=True)
-    logging.debug(f"DataFrame shape after sorting: {df_copy.shape}")
+    logger.debug(f"DataFrame shape after sorting: {df_copy.shape}")
 
     # Mark duplicates within each group (the first row in each group has count=0)
     df_copy["__dup_indicator"] = df_copy.groupby(group_cols).cumcount()
@@ -221,7 +223,7 @@ def mark_potential_duplicates(
 
     # Log how many duplicates we have
     num_duplicates = df_copy["__is_duplicate"].sum()
-    logging.debug(f"Number of duplicates found: {num_duplicates}")
+    logger.debug(f"Number of duplicates found: {num_duplicates}")
 
     # Prepare a list for the new flags
     new_flags: list[list[str]] = []
@@ -231,12 +233,12 @@ def mark_potential_duplicates(
         else:
             new_flags.append([])
 
-    logging.debug("Combining existing flags with new duplicate flags.")
+    logger.debug("Combining existing flags with new duplicate flags.")
     combined_flags = []
     for i, row_tuple in enumerate(df_copy.itertuples(index=False)):
         # itertuples returns a named tuple - access Flag attribute safely
         # Use getattr to avoid mypy errors with dynamic pandas named tuple attributes
-        existing_flag = getattr(row_tuple, "Flag")  # noqa: B009
+        existing_flag = row_tuple.Flag
         dup_flag_list = new_flags[i]
 
         if existing_flag == "Not flagged":
@@ -252,9 +254,9 @@ def mark_potential_duplicates(
     df_copy["Flag"] = combined_flags
 
     # Restore original ordering
-    logging.debug("Restoring original row order.")
+    logger.debug("Restoring original row order.")
     df_copy.sort_values(by="__original_index", inplace=True)
     df_copy.drop(columns=["__original_index", "__dup_indicator", "__is_duplicate"], inplace=True)
 
-    logging.debug(f"Done marking potential duplicates. Final shape: {df_copy.shape}")
+    logger.debug(f"Done marking potential duplicates. Final shape: {df_copy.shape}")
     return df_copy

--- a/vntyper/scripts/generate_report.py
+++ b/vntyper/scripts/generate_report.py
@@ -1,15 +1,16 @@
-#!/usr/bin/env python3
 # vntyper/scripts/generate_report.py
 
 import json
 import logging
 import os
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
 from jinja2 import Environment, FileSystemLoader
+
+logger = logging.getLogger(__name__)
 
 
 def load_pipeline_summary(summary_file_path):
@@ -22,17 +23,17 @@ def load_pipeline_summary(summary_file_path):
     Returns:
         dict: The loaded summary dictionary or an empty dict if load fails.
     """
-    logging.info("Loading pipeline summary from %s", summary_file_path)
+    logger.info("Loading pipeline summary from %s", summary_file_path)
     if not os.path.exists(summary_file_path):
-        logging.error("Pipeline summary file not found: %s", summary_file_path)
+        logger.error("Pipeline summary file not found: %s", summary_file_path)
         return {}
     try:
         with open(summary_file_path) as f:
             summary = json.load(f)
-        logging.debug("Pipeline summary loaded successfully.")
+        logger.debug("Pipeline summary loaded successfully.")
         return summary
     except Exception as e:
-        logging.error("Failed to load pipeline summary: %s", e)
+        logger.error("Failed to load pipeline summary: %s", e)
         return {}
 
 
@@ -42,17 +43,17 @@ def run_igv_report(bed_file, bam_file, fasta_file, output_html, flanking=50, vcf
     is not explicitly set, we fall back to config's default_values.flanking.
     Skips passing None for track arguments (vcf_file or bam_file).
     """
-    logging.debug("run_igv_report called with:")
-    logging.debug("  bed_file=%s", bed_file)
-    logging.debug("  bam_file=%s", bam_file)
-    logging.debug("  fasta_file=%s", fasta_file)
-    logging.debug("  output_html=%s", output_html)
-    logging.debug("  vcf_file=%s", vcf_file)
-    logging.debug("  flanking=%s", flanking)
+    logger.debug("run_igv_report called with:")
+    logger.debug("  bed_file=%s", bed_file)
+    logger.debug("  bam_file=%s", bam_file)
+    logger.debug("  fasta_file=%s", fasta_file)
+    logger.debug("  output_html=%s", output_html)
+    logger.debug("  vcf_file=%s", vcf_file)
+    logger.debug("  flanking=%s", flanking)
 
     if config is not None and flanking == 50:
         flanking = config.get("default_values", {}).get("flanking", 50)
-        logging.debug("Flanking region set to %s based on config.", flanking)
+        logger.debug("Flanking region set to %s based on config.", flanking)
 
     bed_file = str(bed_file) if bed_file else None
     bam_file = str(bam_file) if bam_file else None
@@ -77,35 +78,35 @@ def run_igv_report(bed_file, bam_file, fasta_file, output_html, flanking=50, vcf
         # Verify file exists before adding to tracks (defensive programming)
         if os.path.exists(vcf_file):
             tracks.append(str(vcf_file))
-            logging.debug(f"Adding VCF track: {vcf_file}")
+            logger.debug(f"Adding VCF track: {vcf_file}")
         else:
-            logging.warning(f"VCF file specified but not found: {vcf_file}. Skipping VCF track.")
+            logger.warning(f"VCF file specified but not found: {vcf_file}. Skipping VCF track.")
     else:
-        logging.info("No VCF file provided. IGV report will not include VCF track.")
+        logger.info("No VCF file provided. IGV report will not include VCF track.")
 
     if bam_file:
         if os.path.exists(bam_file):
             tracks.append(str(bam_file))
-            logging.debug(f"Adding BAM track: {bam_file}")
+            logger.debug(f"Adding BAM track: {bam_file}")
         else:
-            logging.warning(f"BAM file specified but not found: {bam_file}. Skipping BAM track.")
+            logger.warning(f"BAM file specified but not found: {bam_file}. Skipping BAM track.")
 
     if not tracks:
-        logging.error("No valid tracks (VCF or BAM) available for IGV report. Report may be empty or fail.")
+        logger.error("No valid tracks (VCF or BAM) available for IGV report. Report may be empty or fail.")
 
     igv_report_cmd.extend(tracks)
     igv_report_cmd.extend(["--output", output_html])
 
-    logging.debug("IGV report command: %s", " ".join([str(x) for x in igv_report_cmd if x]))
+    logger.debug("IGV report command: %s", " ".join([str(x) for x in igv_report_cmd if x]))
     try:
-        logging.info("Running IGV report: %s", " ".join([str(x) for x in igv_report_cmd if x]))
+        logger.info("Running IGV report: %s", " ".join([str(x) for x in igv_report_cmd if x]))
         subprocess.run(igv_report_cmd, check=True)
-        logging.info("IGV report successfully generated at %s", output_html)
+        logger.info("IGV report successfully generated at %s", output_html)
     except subprocess.CalledProcessError as e:
-        logging.error("Error generating IGV report: %s", e)
+        logger.error("Error generating IGV report: %s", e)
         raise
     except Exception as e:
-        logging.error("Unexpected error generating IGV report: %s", e)
+        logger.error("Unexpected error generating IGV report: %s", e)
         raise
 
 
@@ -115,7 +116,7 @@ def extract_igv_content(igv_report_html):
     the tableJson variable, and the sessionDictionary variable from the script.
     Returns empty strings if not found or on error.
     """
-    logging.debug("extract_igv_content called with igv_report_html=%s", igv_report_html)
+    logger.debug("extract_igv_content called with igv_report_html=%s", igv_report_html)
     try:
         with open(igv_report_html) as f:
             content = f.read()
@@ -124,7 +125,7 @@ def extract_igv_content(igv_report_html):
         igv_end = content.find("</body>")
 
         if igv_start == -1 or igv_end == -1:
-            logging.error("Failed to extract IGV content from report.")
+            logger.error("Failed to extract IGV content from report.")
             return "", "", ""
 
         igv_content = content[igv_start:igv_end].strip()
@@ -137,13 +138,13 @@ def extract_igv_content(igv_report_html):
         session_dict_end = content.find("\n", session_dict_start)
         session_dictionary = content[session_dict_start:session_dict_end].strip()
 
-        logging.info("Successfully extracted IGV content, tableJson, and sessionDictionary.")
+        logger.info("Successfully extracted IGV content, tableJson, and sessionDictionary.")
         return igv_content, table_json, session_dictionary
     except FileNotFoundError:
-        logging.error("IGV report file not found: %s", igv_report_html)
+        logger.error("IGV report file not found: %s", igv_report_html)
         return "", "", ""
     except Exception as e:
-        logging.error("Unexpected error extracting IGV content: %s", e)
+        logger.error("Unexpected error extracting IGV content: %s", e)
         return "", "", ""
 
 
@@ -152,17 +153,17 @@ def load_fastp_output(fastp_file):
     Loads fastp JSON output (e.g., output.json) for summary metrics if available.
     Returns an empty dict if file not found or if parsing fails.
     """
-    logging.debug("load_fastp_output called with fastp_file=%s", fastp_file)
+    logger.debug("load_fastp_output called with fastp_file=%s", fastp_file)
     if not os.path.exists(fastp_file):
-        logging.warning("fastp output file not found: %s", fastp_file)
+        logger.warning("fastp output file not found: %s", fastp_file)
         return {}
     try:
         with open(fastp_file) as f:
             data = json.load(f)
-        logging.debug("fastp output successfully loaded.")
+        logger.debug("fastp output successfully loaded.")
         return data
     except Exception as e:
-        logging.error("Failed to load or parse fastp output: %s", e)
+        logger.error("Failed to load or parse fastp output: %s", e)
         return {}
 
 
@@ -171,20 +172,20 @@ def load_pipeline_log(log_file):
     Loads the pipeline log content from the specified log_file.
     Returns a placeholder string if not found or on error.
     """
-    logging.info("Loading pipeline log from %s", log_file)
+    logger.info("Loading pipeline log from %s", log_file)
     if not log_file:
-        logging.warning("No pipeline log file provided; skipping log loading.")
+        logger.warning("No pipeline log file provided; skipping log loading.")
         return "No pipeline log file was provided."
     if not os.path.exists(log_file):
-        logging.warning("Pipeline log file not found: %s", log_file)
+        logger.warning("Pipeline log file not found: %s", log_file)
         return "Pipeline log file not found."
     try:
         with open(log_file) as f:
             content = f.read()
-        logging.debug("Pipeline log successfully loaded.")
+        logger.debug("Pipeline log successfully loaded.")
         return content
     except Exception as e:
-        logging.error("Failed to read pipeline log file: %s", e)
+        logger.error("Failed to read pipeline log file: %s", e)
         return "Failed to load pipeline log."
 
 
@@ -201,10 +202,10 @@ def load_report_config():
     try:
         with open(config_path) as f:
             report_config = json.load(f)
-        logging.info("Loaded report config from %s", config_path)
+        logger.info("Loaded report config from %s", config_path)
         return report_config
     except Exception as e:
-        logging.error("Failed to load report config: %s", e)
+        logger.error("Failed to load report config: %s", e)
         return {}
 
 
@@ -225,22 +226,22 @@ def compute_algorithm_result(df, logic_config):
         str: The computed algorithm result.
     """
     if df.empty:
-        logging.debug("DataFrame is empty; returning default result.")
+        logger.debug("DataFrame is empty; returning default result.")
         return logic_config.get("default", "none")
     row = df.iloc[0]
-    logging.debug("Data row for evaluation: %s", row.to_dict())
-    logging.debug("Logic configuration: %s", logic_config)
+    logger.debug("Data row for evaluation: %s", row.to_dict())
+    logger.debug("Logic configuration: %s", logic_config)
     for idx, rule in enumerate(logic_config.get("rules", [])):
-        logging.debug("Evaluating rule %s: %s", idx, rule)
+        logger.debug("Evaluating rule %s: %s", idx, rule)
         conditions = rule.get("conditions", {})
         rule_matches = True
         for col, expected in conditions.items():
             if col not in row:
-                logging.debug("Rule %s: Column '%s' not found; rule fails.", idx, col)
+                logger.debug("Rule %s: Column '%s' not found; rule fails.", idx, col)
                 rule_matches = False
                 break
             actual = str(row.get(col, "")).strip()
-            logging.debug(
+            logger.debug(
                 "Rule %s, column '%s': actual='%s', expected='%s'",
                 idx,
                 col,
@@ -252,7 +253,7 @@ def compute_algorithm_result(df, logic_config):
                 exp_val = expected.get("value")
                 if op == "==":
                     if actual != str(exp_val).strip():
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s == %s' not met (actual='%s').",
                             idx,
                             col,
@@ -263,7 +264,7 @@ def compute_algorithm_result(df, logic_config):
                         break
                 elif op == "!=":
                     if actual == str(exp_val).strip():
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s != %s' not met (actual='%s').",
                             idx,
                             col,
@@ -276,7 +277,7 @@ def compute_algorithm_result(df, logic_config):
                     if not isinstance(exp_val, list):
                         exp_val = [exp_val]
                     if actual not in exp_val:
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s in %s' not met (actual='%s').",
                             idx,
                             col,
@@ -289,7 +290,7 @@ def compute_algorithm_result(df, logic_config):
                     if not isinstance(exp_val, list):
                         exp_val = [exp_val]
                     if actual in exp_val:
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s not in %s' not met (actual='%s').",
                             idx,
                             col,
@@ -299,7 +300,7 @@ def compute_algorithm_result(df, logic_config):
                         rule_matches = False
                         break
                 else:
-                    logging.debug(
+                    logger.debug(
                         "Rule %s: Unsupported operator '%s' for column '%s'.",
                         idx,
                         op,
@@ -310,7 +311,7 @@ def compute_algorithm_result(df, logic_config):
             else:
                 if isinstance(expected, list):
                     if actual not in expected:
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s in %s' not met (actual='%s').",
                             idx,
                             col,
@@ -321,7 +322,7 @@ def compute_algorithm_result(df, logic_config):
                         break
                 else:
                     if actual != str(expected):
-                        logging.debug(
+                        logger.debug(
                             "Rule %s: Condition '%s == %s' not met (actual='%s').",
                             idx,
                             col,
@@ -332,11 +333,11 @@ def compute_algorithm_result(df, logic_config):
                         break
         if rule_matches:
             result = rule.get("result")
-            logging.debug("Rule %s PASSED; returning result: %s", idx, result)
+            logger.debug("Rule %s PASSED; returning result: %s", idx, result)
             return result
         else:
-            logging.debug("Rule %s did not pass.", idx)
-    logging.debug("No rule matched; returning default result.")
+            logger.debug("Rule %s did not pass.", idx)
+    logger.debug("No rule matched; returning default result.")
     return logic_config.get("default", "none")
 
 
@@ -366,23 +367,23 @@ def build_screening_summary(
     try:
         kestrel_logic = report_config.get("algorithm_logic", {}).get("kestrel", {})
         computed_kestrel = compute_algorithm_result(kestrel_df, kestrel_logic)
-        logging.debug("Computed Kestrel result: %s", computed_kestrel)
+        logger.debug("Computed Kestrel result: %s", computed_kestrel)
 
         advntr_logic = report_config.get("algorithm_logic", {}).get("advntr", {})
         computed_advntr = compute_algorithm_result(advntr_df, advntr_logic) if advntr_available else "none"
-        logging.debug("Computed adVNTR result: %s", computed_advntr)
+        logger.debug("Computed adVNTR result: %s", computed_advntr)
 
         quality_metrics_pass = True
         if mean_vntr_coverage is not None and mean_vntr_coverage < mean_vntr_cov_threshold:
             quality_metrics_pass = False
-        logging.debug("Quality metrics pass: %s", quality_metrics_pass)
+        logger.debug("Quality metrics pass: %s", quality_metrics_pass)
 
         current_conditions = {
             "kestrel_result": computed_kestrel,
             "advntr_result": computed_advntr,
             "quality_metrics_pass": quality_metrics_pass,
         }
-        logging.debug("Unified screening conditions: %s", current_conditions)
+        logger.debug("Unified screening conditions: %s", current_conditions)
 
         unified_rules = report_config.get("screening_summary_rules", [])
         default_message = report_config.get(
@@ -399,18 +400,18 @@ def build_screening_summary(
             conditions = rule.get("conditions", {})
             if all(condition_matches(current_conditions.get(key), conditions.get(key)) for key in conditions):
                 summary_text = rule.get("message", "")
-                logging.debug("Unified rule matched: %s", conditions)
+                logger.debug("Unified rule matched: %s", conditions)
                 break
 
         if not summary_text:
             summary_text = default_message
-            logging.debug("No unified rule matched; using default screening message.")
+            logger.debug("No unified rule matched; using default screening message.")
 
     except Exception as ex:
-        logging.error("Exception in build_screening_summary: %s", ex)
+        logger.error("Exception in build_screening_summary: %s", ex)
         summary_text = "No summary available."
 
-    logging.debug("Final screening summary: %s", summary_text)
+    logger.debug("Final screening summary: %s", summary_text)
     return summary_text
 
 
@@ -449,14 +450,14 @@ def generate_summary_report(
     Raises:
         ValueError: If config is not provided.
     """
-    logging.debug("---- DEBUG: Entered generate_summary_report ----")
-    logging.debug(
+    logger.debug("---- DEBUG: Entered generate_summary_report ----")
+    logger.debug(
         "Called with output_dir=%s, template_dir=%s, report_file=%s",
         output_dir,
         template_dir,
         report_file,
     )
-    logging.debug(
+    logger.debug(
         "bed_file=%s, bam_file=%s, fasta_file=%s, flanking=%s, log_file=%s, vcf_file=%s",
         bed_file,
         bam_file,
@@ -475,7 +476,7 @@ def generate_summary_report(
     # Resolve flanking region from main config if needed.
     if flanking == 50 and config is not None:
         flanking = config.get("default_values", {}).get("flanking", 50)
-        logging.debug("Flanking region set to %s based on config.", flanking)
+        logger.debug("Flanking region set to %s based on config.", flanking)
 
     thresholds = config.get("thresholds", {})
     mean_vntr_cov_threshold = thresholds.get("mean_vntr_coverage", 100)
@@ -529,17 +530,17 @@ def generate_summary_report(
                     vntr_region_length = int(coverage_data.get("region_length", 0))
                     vntr_uncovered_bases = int(coverage_data.get("uncovered_bases", 0))
                     percent_vntr_uncovered = float(coverage_data.get("percent_uncovered", 0))
-                    logging.debug("All VNTR coverage statistics extracted successfully")
-                    logging.debug(f"Mean VNTR coverage: {mean_vntr_coverage}")
-                    logging.debug(f"Median VNTR coverage: {median_vntr_coverage}")
-                    logging.debug(f"StdDev VNTR coverage: {stdev_vntr_coverage}")
-                    logging.debug(f"Min VNTR coverage: {min_vntr_coverage}")
-                    logging.debug(f"Max VNTR coverage: {max_vntr_coverage}")
-                    logging.debug(f"VNTR region length: {vntr_region_length}")
-                    logging.debug(f"VNTR uncovered bases: {vntr_uncovered_bases}")
-                    logging.debug(f"Percent VNTR uncovered: {percent_vntr_uncovered}%")
+                    logger.debug("All VNTR coverage statistics extracted successfully")
+                    logger.debug(f"Mean VNTR coverage: {mean_vntr_coverage}")
+                    logger.debug(f"Median VNTR coverage: {median_vntr_coverage}")
+                    logger.debug(f"StdDev VNTR coverage: {stdev_vntr_coverage}")
+                    logger.debug(f"Min VNTR coverage: {min_vntr_coverage}")
+                    logger.debug(f"Max VNTR coverage: {max_vntr_coverage}")
+                    logger.debug(f"VNTR region length: {vntr_region_length}")
+                    logger.debug(f"VNTR uncovered bases: {vntr_uncovered_bases}")
+                    logger.debug(f"Percent VNTR uncovered: {percent_vntr_uncovered}%")
                 except Exception as e:
-                    logging.error("Error parsing VNTR coverage statistics: %s", e)
+                    logger.error("Error parsing VNTR coverage statistics: %s", e)
                     # Keep default None values for failed extractions
             break
 
@@ -577,7 +578,7 @@ def generate_summary_report(
             try:
                 kestrel_df["Depth Score"] = pd.to_numeric(kestrel_df["Depth Score"], errors="coerce")
             except Exception as e:
-                logging.warning("Could not convert 'Depth Score' to numeric: %s", e)
+                logger.warning("Could not convert 'Depth Score' to numeric: %s", e)
             kestrel_df = kestrel_df.sort_values(by="Depth Score", ascending=False)
         # Create a copy of the sorted dataframe (without HTML formatting) for matching.
         kestrel_df_raw = kestrel_df.copy()
@@ -594,11 +595,11 @@ def generate_summary_report(
                     )
                 )
             )
-        logging.debug("Kestrel data extracted from summary and formatted.")
+        logger.debug("Kestrel data extracted from summary and formatted.")
     else:
         kestrel_df = pd.DataFrame()
         kestrel_df_raw = pd.DataFrame()
-        logging.warning("No Kestrel data found in pipeline summary.")
+        logger.warning("No Kestrel data found in pipeline summary.")
 
     if advntr_data:
         advntr_df = pd.DataFrame(advntr_data)
@@ -615,7 +616,7 @@ def generate_summary_report(
             "Flag",
         ]
         advntr_df = advntr_df[[col for col in advntr_columns if col in advntr_df.columns]]
-        logging.debug("adVNTR data extracted from summary and formatted.")
+        logger.debug("adVNTR data extracted from summary and formatted.")
     else:
         advntr_df = pd.DataFrame()
 
@@ -623,7 +624,7 @@ def generate_summary_report(
 
     # IGV report generation (if applicable)
     if bed_file and os.path.exists(bed_file):
-        logging.info("Running IGV report for BED file: %s", bed_file)
+        logger.info("Running IGV report for BED file: %s", bed_file)
         igv_report_file = Path(output_dir) / "igv_report.html"
         run_igv_report(
             bed_file,
@@ -635,13 +636,13 @@ def generate_summary_report(
             config=config,
         )
     else:
-        logging.warning("BED file does not exist or not provided. Skipping IGV report generation.")
+        logger.warning("BED file does not exist or not provided. Skipping IGV report generation.")
         igv_report_file = None
 
     if igv_report_file and igv_report_file.exists():
         igv_content, table_json, session_dictionary = extract_igv_content(igv_report_file)
     else:
-        logging.warning("IGV report file not found. Skipping IGV content.")
+        logger.warning("IGV report file not found. Skipping IGV content.")
         igv_content, table_json, session_dictionary = "", "", ""
 
     fastp_file = Path(output_dir) / "fastq_bam_processing/output.json"
@@ -650,23 +651,23 @@ def generate_summary_report(
     if mean_vntr_coverage is not None and mean_vntr_coverage < mean_vntr_cov_threshold:
         coverage_icon = '<span style="color:red;font-weight:bold;">&#9888;</span>'
         coverage_color = "red"
-        logging.debug("Mean VNTR coverage is below the threshold.")
+        logger.debug("Mean VNTR coverage is below the threshold.")
     else:
         coverage_icon = '<span style="color:green;font-weight:bold;">&#10004;</span>'
         coverage_color = "green"
-        logging.debug("Mean VNTR coverage is above the threshold.")
+        logger.debug("Mean VNTR coverage is above the threshold.")
 
     # Check if percent_vntr_uncovered exceeds threshold
     if percent_vntr_uncovered is not None and percent_vntr_uncovered > percent_vntr_uncovered_threshold:
         uncovered_icon = '<span style="color:red;font-weight:bold;">&#9888;</span>'
         uncovered_color = "red"
-        logging.debug(
+        logger.debug(
             f"Percent VNTR uncovered ({percent_vntr_uncovered}%) exceeds the threshold ({percent_vntr_uncovered_threshold}%)."
         )
     else:
         uncovered_icon = '<span style="color:green;font-weight:bold;">&#10004;</span>'
         uncovered_color = "green"
-        logging.debug(
+        logger.debug(
             f"Percent VNTR uncovered ({percent_vntr_uncovered}%) is below the threshold ({percent_vntr_uncovered_threshold}%)."
         )
 
@@ -693,27 +694,27 @@ def generate_summary_report(
         passed_filter_reads = filtering_result.get("passed_filter_reads", 0)
         if total_reads_before > 0:
             passed_filter_rate = passed_filter_reads / total_reads_before
-            logging.debug("Passed filter rate calculated: %.2f", passed_filter_rate)
+            logger.debug("Passed filter rate calculated: %.2f", passed_filter_rate)
         else:
             passed_filter_rate = None
-            logging.debug("Total reads before filtering is zero; passed filter rate set to None.")
+            logger.debug("Total reads before filtering is zero; passed filter rate set to None.")
         sequencing_str = summary_fastp.get("sequencing", "")
-        logging.debug("Sequencing setup: %s", sequencing_str)
+        logger.debug("Sequencing setup: %s", sequencing_str)
 
     def warn_icon(value, cutoff, higher_better=True):
         if value is None:
-            logging.debug("warn_icon called with value=None; returning empty strings.")
+            logger.debug("warn_icon called with value=None; returning empty strings.")
             return "", ""
         if higher_better:
             if value < cutoff:
-                logging.debug(
+                logger.debug(
                     "Value %s is below the cutoff %s (higher_better=True).",
                     value,
                     cutoff,
                 )
                 return '<span style="color:red;font-weight:bold;">&#9888;</span>', "red"
             else:
-                logging.debug(
+                logger.debug(
                     "Value %s is above or equal to the cutoff %s (higher_better=True).",
                     value,
                     cutoff,
@@ -724,14 +725,14 @@ def generate_summary_report(
                 )
         else:
             if value > cutoff:
-                logging.debug(
+                logger.debug(
                     "Value %s is above the cutoff %s (higher_better=False).",
                     value,
                     cutoff,
                 )
                 return '<span style="color:red;font-weight:bold;">&#9888;</span>', "red"
             else:
-                logging.debug(
+                logger.debug(
                     "Value %s is below or equal to the cutoff %s (higher_better=False).",
                     value,
                     cutoff,
@@ -752,7 +753,7 @@ def generate_summary_report(
         index=False,
         escape=False,
     )
-    logging.debug("Kestrel results converted to HTML.")
+    logger.debug("Kestrel results converted to HTML.")
 
     if advntr_available:
         if not advntr_df.empty:
@@ -760,13 +761,13 @@ def generate_summary_report(
                 classes="table table-bordered table-striped hover compact table-sm",
                 index=False,
             )
-            logging.debug("adVNTR results converted to HTML.")
+            logger.debug("adVNTR results converted to HTML.")
         else:
             advntr_html = "<p>No pathogenic variants identified by adVNTR.</p>"
-            logging.debug("adVNTR was performed but no variants identified; adding negative message.")
+            logger.debug("adVNTR was performed but no variants identified; adding negative message.")
     else:
         advntr_html = "<p>adVNTR genotyping was not performed.</p>"
-        logging.debug("adVNTR was not performed; adding message to report.")
+        logger.debug("adVNTR was not performed; adding message to report.")
 
     # Extract cross-match summary message from the pipeline summary if available.
     cross_match_message = ""
@@ -782,9 +783,9 @@ def generate_summary_report(
     env = Environment(loader=FileSystemLoader(template_dir))
     try:
         template = env.get_template("report_template.html")
-        logging.debug("Jinja2 template 'report_template.html' loaded successfully.")
+        logger.debug("Jinja2 template 'report_template.html' loaded successfully.")
     except Exception as e:
-        logging.error("Failed to load Jinja2 template: %s", e)
+        logger.error("Failed to load Jinja2 template: %s", e)
         raise
 
     # Use the sorted (and raw) kestrel dataframe for matching.
@@ -796,7 +797,7 @@ def generate_summary_report(
         mean_vntr_cov_threshold,
         report_config,
     )
-    logging.debug("Summary text generated: %s", summary_text)
+    logger.debug("Summary text generated: %s", summary_text)
 
     context = {
         "kestrel_highlight": kestrel_html,
@@ -806,7 +807,7 @@ def generate_summary_report(
         "igv_content": igv_content,
         "table_json": table_json,
         "session_dictionary": session_dictionary,
-        "report_date": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "report_date": datetime.now(timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S"),
         "input_files": input_files,
         "pipeline_version": pipeline_version,
         "header_warning": header_warning,
@@ -845,16 +846,16 @@ def generate_summary_report(
 
     try:
         rendered_html = template.render(context)
-        logging.debug("Report template rendered successfully.")
+        logger.debug("Report template rendered successfully.")
     except Exception as e:
-        logging.error("Failed to render the report template: %s", e)
+        logger.error("Failed to render the report template: %s", e)
         raise
 
     report_file_path = Path(output_dir) / report_file
     try:
         with open(report_file_path, "w") as f:
             f.write(rendered_html)
-        logging.info("Summary report generated and saved to %s", report_file_path)
+        logger.info("Summary report generated and saved to %s", report_file_path)
     except Exception as e:
-        logging.error("Failed to write the summary report: %s", e)
+        logger.error("Failed to write the summary report: %s", e)
         raise

--- a/vntyper/scripts/install_references.py
+++ b/vntyper/scripts/install_references.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python3
 # vntyper/scripts/install_references.py
+
+from __future__ import annotations
 
 import gzip
 import hashlib
@@ -11,8 +12,10 @@ import sys
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from urllib.request import urlretrieve
+
+logger = logging.getLogger(__name__)
 
 
 def load_install_config(config_path: Path) -> dict[str, Any]:
@@ -29,7 +32,7 @@ def load_install_config(config_path: Path) -> dict[str, Any]:
         SystemExit: If the configuration file is missing or malformed.
     """
     if not config_path.exists():
-        logging.error(f"Installation config file not found at {config_path}")
+        logger.error(f"Installation config file not found at {config_path}")
         sys.exit(1)
 
     try:
@@ -37,10 +40,10 @@ def load_install_config(config_path: Path) -> dict[str, Any]:
             config = json.load(f)
         return config
     except json.JSONDecodeError as e:
-        logging.error(f"Error parsing JSON config: {e}")
+        logger.error(f"Error parsing JSON config: {e}")
         sys.exit(1)
     except Exception as e:
-        logging.error(f"Unexpected error reading config: {e}")
+        logger.error(f"Unexpected error reading config: {e}")
         sys.exit(1)
 
 
@@ -56,16 +59,16 @@ def download_file(url: str, dest_path: Path):
         SystemExit: If the download fails.
     """
     if dest_path.exists():
-        logging.info(f"File already exists at {dest_path}. Skipping download.")
+        logger.info(f"File already exists at {dest_path}. Skipping download.")
         return
 
-    logging.info(f"Downloading from {url} to {dest_path}...")
+    logger.info(f"Downloading from {url} to {dest_path}...")
     try:
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         urlretrieve(url, dest_path)
-        logging.info(f"Successfully downloaded {dest_path.name}")
+        logger.info(f"Successfully downloaded {dest_path.name}")
     except Exception as e:
-        logging.error(f"Failed to download {url}: {e}")
+        logger.error(f"Failed to download {url}: {e}")
         sys.exit(1)
 
 
@@ -82,17 +85,17 @@ def calculate_md5(file_path: Path) -> str:
     Raises:
         SystemExit: If reading the file fails.
     """
-    logging.debug(f"Calculating MD5 for {file_path}...")
+    logger.debug(f"Calculating MD5 for {file_path}...")
     hash_md5 = hashlib.md5()
     try:
         with file_path.open("rb") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_md5.update(chunk)
         md5_checksum = hash_md5.hexdigest()
-        logging.debug(f"MD5 for {file_path} is {md5_checksum}")
+        logger.debug(f"MD5 for {file_path} is {md5_checksum}")
         return md5_checksum
     except Exception as e:
-        logging.error(f"Failed to calculate MD5 for {file_path}: {e}")
+        logger.error(f"Failed to calculate MD5 for {file_path}: {e}")
         sys.exit(1)
 
 
@@ -108,13 +111,13 @@ def execute_index_command(index_command: str, fasta_path: Path):
         SystemExit: If the indexing fails.
     """
     command = index_command.format(path=str(fasta_path))
-    logging.info(f"Executing indexing command: {command}")
+    logger.info(f"Executing indexing command: {command}")
     try:
         args = command.split()
         subprocess.run(args, check=True, capture_output=True)
-        logging.info(f"Successfully executed: {command}")
+        logger.info(f"Successfully executed: {command}")
     except subprocess.CalledProcessError as e:
-        logging.error(f"Indexing command failed for {fasta_path}: {e.stderr.decode().strip()}")
+        logger.error(f"Indexing command failed for {fasta_path}: {e.stderr.decode().strip()}")
         sys.exit(1)
 
 
@@ -136,13 +139,13 @@ def check_executable_available(executable: str) -> bool:
     try:
         result = subprocess.run(["which", executable], capture_output=True, text=True, check=False)
         if result.returncode == 0:
-            logging.debug(f"Found executable: {executable} at {result.stdout.strip()}")
+            logger.debug(f"Found executable: {executable} at {result.stdout.strip()}")
             return True
         else:
-            logging.debug(f"Executable not found: {executable}")
+            logger.debug(f"Executable not found: {executable}")
             return False
     except Exception as e:
-        logging.debug(f"Error checking executable {executable}: {e}")
+        logger.debug(f"Error checking executable {executable}: {e}")
         return False
 
 
@@ -162,9 +165,9 @@ def get_enabled_aligners(aligner_config: dict[str, Any]) -> dict[str, dict[str, 
             executable = aligner_info.get("executable", aligner_name)
             if check_executable_available(executable):
                 enabled[aligner_name] = aligner_info
-                logging.info(f"  ✓ {aligner_name}: {aligner_info.get('description', 'No description')}")
+                logger.info(f"  ✓ {aligner_name}: {aligner_info.get('description', 'No description')}")
             else:
-                logging.warning(
+                logger.warning(
                     f"  ✗ {aligner_name} is enabled in config but executable '{executable}' not found. "
                     f"Skipping this aligner."
                 )
@@ -228,7 +231,7 @@ def check_index_exists(ref_path: Path, aligner_name: str, aligner_info: dict[str
         for ext in index_files:
             index_file_path = Path(str(ref_path) + ext)
             if not index_file_path.exists():
-                logging.debug(f"Missing index file: {index_file_path}")
+                logger.debug(f"Missing index file: {index_file_path}")
                 return False
         return True
 
@@ -248,7 +251,7 @@ def execute_aligner_index(ref_path: Path, aligner_name: str, aligner_info: dict[
     """
     index_command_template = aligner_info.get("index_command", "")
     if not index_command_template:
-        logging.error(f"No index_command specified for {aligner_name}")
+        logger.error(f"No index_command specified for {aligner_name}")
         return False
 
     # Prepare command parameters
@@ -273,18 +276,18 @@ def execute_aligner_index(ref_path: Path, aligner_name: str, aligner_info: dict[
     try:
         command = index_command_template.format(**params)
     except KeyError as e:
-        logging.error(f"Missing parameter in index command for {aligner_name}: {e}")
+        logger.error(f"Missing parameter in index command for {aligner_name}: {e}")
         return False
 
-    logging.info(f"  Indexing with {aligner_name}...")
-    logging.debug(f"  Command: {command}")
+    logger.info(f"  Indexing with {aligner_name}...")
+    logger.debug(f"  Command: {command}")
 
     try:
         subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
-        logging.info(f"  ✓ {aligner_name} indexing complete")
+        logger.info(f"  ✓ {aligner_name} indexing complete")
         return True
     except subprocess.CalledProcessError as e:
-        logging.error(f"  ✗ {aligner_name} indexing failed: {e.stderr.strip()}")
+        logger.error(f"  ✗ {aligner_name} indexing failed: {e.stderr.strip()}")
         return False
 
 
@@ -305,13 +308,13 @@ def index_reference_with_aligners(
     """
     results = {}
 
-    logging.info(f"Indexing reference: {ref_path.name}")
-    logging.info(f"  Using {len(aligners)} aligner(s) with {threads} threads")
+    logger.info(f"Indexing reference: {ref_path.name}")
+    logger.info(f"  Using {len(aligners)} aligner(s) with {threads} threads")
 
     for aligner_name, aligner_info in aligners.items():
         # Check if index already exists
         if not force_reindex and check_index_exists(ref_path, aligner_name, aligner_info):
-            logging.info(f"  ✓ {aligner_name} index already exists, skipping")
+            logger.info(f"  ✓ {aligner_name} index already exists, skipping")
             results[aligner_name] = True
             continue
 
@@ -334,17 +337,17 @@ def update_config(config_path: Path, references: dict[str, Path]):
         SystemExit: If updating the config fails.
     """
     if not config_path.exists():
-        logging.error(f"Main config file {config_path} does not exist. Cannot update references.")
+        logger.error(f"Main config file {config_path} does not exist. Cannot update references.")
         sys.exit(1)
 
     try:
         with config_path.open("r") as f:
             config = json.load(f)
     except json.JSONDecodeError as e:
-        logging.error(f"Error parsing main config.json: {e}")
+        logger.error(f"Error parsing main config.json: {e}")
         sys.exit(1)
     except Exception as e:
-        logging.error(f"Unexpected error reading main config.json: {e}")
+        logger.error(f"Unexpected error reading main config.json: {e}")
         sys.exit(1)
 
     if "reference_data" not in config:
@@ -356,9 +359,9 @@ def update_config(config_path: Path, references: dict[str, Path]):
     try:
         with config_path.open("w") as f:
             json.dump(config, f, indent=2)
-        logging.info(f"Successfully updated {config_path} with new reference paths.")
+        logger.info(f"Successfully updated {config_path} with new reference paths.")
     except Exception as e:
-        logging.error(f"Failed to write updated config.json: {e}")
+        logger.error(f"Failed to write updated config.json: {e}")
         sys.exit(1)
 
 
@@ -368,7 +371,7 @@ def process_ucsc_references(
     bwa_path: str,
     skip_indexing: bool,
     md5_dict: dict[str, str],
-    aligners: Optional[dict[str, dict[str, Any]]] = None,
+    aligners: dict[str, dict[str, Any]] | None = None,
     index_threads: int = 4,
 ):
     """
@@ -389,7 +392,7 @@ def process_ucsc_references(
         index_command = ref_info.get("index_command", None)
 
         if not url or not target_path_str:
-            logging.warning(f"Missing URL or target_path for UCSC reference {ref_name}. Skipping.")
+            logger.warning(f"Missing URL or target_path for UCSC reference {ref_name}. Skipping.")
             continue
 
         target_path = output_dir / target_path_str
@@ -398,35 +401,35 @@ def process_ucsc_references(
 
         md5_checksum = calculate_md5(target_path)
         md5_dict[str(target_path)] = md5_checksum
-        logging.info(f"MD5 checksum for {target_path.name}: {md5_checksum}")
+        logger.info(f"MD5 checksum for {target_path.name}: {md5_checksum}")
 
         if target_path.suffix == ".zip":
             try:
                 with zipfile.ZipFile(target_path, "r") as zip_ref:
                     zip_ref.extractall(path=target_path)
-                logging.info(f"Successfully extracted {target_path.name}")
+                logger.info(f"Successfully extracted {target_path.name}")
             except Exception as e:
-                logging.error(f"Failed to extract {target_path}: {e}")
+                logger.error(f"Failed to extract {target_path}: {e}")
                 sys.exit(1)
         elif target_path.suffix == ".gz":
             try:
                 output_path = target_path.with_suffix("")
                 with gzip.open(target_path, "rb") as f_in, open(output_path, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)
-                logging.info(f"Successfully extracted {target_path.name} to {output_path.name}")
+                logger.info(f"Successfully extracted {target_path.name} to {output_path.name}")
             except Exception as e:
-                logging.error(f"Failed to extract {target_path}: {e}")
+                logger.error(f"Failed to extract {target_path}: {e}")
                 sys.exit(1)
         elif target_path.suffixes[-2:] == [".tar", ".gz"] or target_path.suffix == ".tgz":
             try:
                 with tarfile.open(target_path, "r:gz") as tar:
                     tar.extractall(path=target_path)
-                logging.info(f"Successfully extracted {target_path.name}")
+                logger.info(f"Successfully extracted {target_path.name}")
             except Exception as e:
-                logging.error(f"Failed to extract {target_path}: {e}")
+                logger.error(f"Failed to extract {target_path}: {e}")
                 sys.exit(1)
         else:
-            logging.warning(f"Unsupported archive format for {target_path}. Skipping extraction.")
+            logger.warning(f"Unsupported archive format for {target_path}. Skipping extraction.")
 
         # Multi-aligner indexing
         if not skip_indexing:
@@ -437,10 +440,10 @@ def process_ucsc_references(
                 index_reference_with_aligners(output_path, aligners, threads=index_threads, force_reindex=False)
             elif index_command:
                 # Fall back to legacy single indexing command
-                logging.warning(f"No aligners configured, using legacy index_command for {output_path.name}")
+                logger.warning(f"No aligners configured, using legacy index_command for {output_path.name}")
                 execute_index_command(index_command, output_path)
         elif skip_indexing:
-            logging.info(f"Skipping indexing for {target_path.with_suffix('')}")
+            logger.info(f"Skipping indexing for {target_path.with_suffix('')}")
 
 
 def process_vntyper_references(
@@ -467,7 +470,7 @@ def process_vntyper_references(
         index_command = ref_info.get("index_command", None)
 
         if not url or not target_path_str:
-            logging.warning(f"Missing URL or target_path for VNtyper reference {ref_name}. Skipping.")
+            logger.warning(f"Missing URL or target_path for VNtyper reference {ref_name}. Skipping.")
             continue
 
         target_path = output_dir / target_path_str
@@ -476,7 +479,7 @@ def process_vntyper_references(
 
         md5_checksum = calculate_md5(target_path)
         md5_dict[str(target_path)] = md5_checksum
-        logging.info(f"MD5 checksum for {target_path.name}: {md5_checksum}")
+        logger.info(f"MD5 checksum for {target_path.name}: {md5_checksum}")
 
         if extract_to:
             extract_dir = output_dir / extract_to
@@ -485,25 +488,25 @@ def process_vntyper_references(
                 try:
                     with zipfile.ZipFile(target_path, "r") as zip_ref:
                         zip_ref.extractall(path=extract_dir)
-                    logging.info(f"Successfully extracted {target_path.name}")
+                    logger.info(f"Successfully extracted {target_path.name}")
                 except Exception as e:
-                    logging.error(f"Failed to extract {target_path}: {e}")
+                    logger.error(f"Failed to extract {target_path}: {e}")
                     sys.exit(1)
             elif target_path.suffixes[-2:] == [".tar", ".gz"] or target_path.suffix == ".tgz":
                 try:
                     with tarfile.open(target_path, "r:gz") as tar:
                         tar.extractall(path=extract_dir)
-                    logging.info(f"Successfully extracted {target_path.name}")
+                    logger.info(f"Successfully extracted {target_path.name}")
                 except Exception as e:
-                    logging.error(f"Failed to extract {target_path}: {e}")
+                    logger.error(f"Failed to extract {target_path}: {e}")
                     sys.exit(1)
             else:
-                logging.warning(f"Unsupported archive format for {target_path}. Skipping extraction.")
+                logger.warning(f"Unsupported archive format for {target_path}. Skipping extraction.")
 
         if index_command and not skip_indexing:
             execute_index_command(index_command, target_path)
         elif index_command and skip_indexing:
-            logging.info(f"Skipping indexing for {target_path}")
+            logger.info(f"Skipping indexing for {target_path}")
 
 
 def process_own_repository_references(
@@ -528,7 +531,7 @@ def process_own_repository_references(
         index_command = file_info.get("index_command", None)
 
         if not url or not target_path_str:
-            logging.warning("Missing URL or target_path for own repository raw file. Skipping.")
+            logger.warning("Missing URL or target_path for own repository raw file. Skipping.")
             continue
 
         target_path = output_dir / target_path_str
@@ -537,12 +540,12 @@ def process_own_repository_references(
 
         md5_checksum = calculate_md5(target_path)
         md5_dict[str(target_path)] = md5_checksum
-        logging.info(f"MD5 checksum for {target_path.name}: {md5_checksum}")
+        logger.info(f"MD5 checksum for {target_path.name}: {md5_checksum}")
 
         if index_command and not skip_indexing:
             execute_index_command(index_command, target_path)
         elif index_command and skip_indexing:
-            logging.info(f"Skipping indexing for {target_path}")
+            logger.info(f"Skipping indexing for {target_path}")
 
 
 def write_md5_checksums(md5_dict: dict[str, str], output_dir: Path):
@@ -559,9 +562,9 @@ def write_md5_checksums(md5_dict: dict[str, str], output_dir: Path):
             for file_path, md5 in md5_dict.items():
                 relative_path = file_path.replace(str(output_dir) + "/", "")
                 f.write(f"{md5}  {relative_path}\n")
-        logging.info(f"MD5 checksums written to {checksum_file}")
+        logger.info(f"MD5 checksums written to {checksum_file}")
     except Exception as e:
-        logging.error(f"Failed to write MD5 checksums to {checksum_file}: {e}")
+        logger.error(f"Failed to write MD5 checksums to {checksum_file}: {e}")
         sys.exit(1)
 
 
@@ -574,11 +577,11 @@ def setup_logging(output_dir: Path):
     """
     log_file = output_dir / "install_references.log"
 
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
 
-    for handler in logger.handlers[:]:
-        logger.removeHandler(handler)
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
 
     c_handler = logging.StreamHandler(sys.stdout)
     f_handler = logging.FileHandler(log_file)
@@ -590,19 +593,19 @@ def setup_logging(output_dir: Path):
     c_handler.setFormatter(formatter)
     f_handler.setFormatter(formatter)
 
-    logger.addHandler(c_handler)
-    logger.addHandler(f_handler)
+    root_logger.addHandler(c_handler)
+    root_logger.addHandler(f_handler)
 
-    logging.info(f"Logging initialized. Logs will be saved to {log_file}")
+    logger.info(f"Logging initialized. Logs will be saved to {log_file}")
 
 
 def main(
     output_dir: Path,
-    config_path: Optional[Path] = None,
+    config_path: Path | None = None,
     skip_indexing: bool = False,
     index_threads: int = 4,
-    aligners_to_use: Optional[list[str]] = None,
-    references_to_process: Optional[list[str]] = None,
+    aligners_to_use: list[str] | None = None,
+    references_to_process: list[str] | None = None,
 ):
     """
     Main function to execute the install_references process.
@@ -633,7 +636,7 @@ def main(
     try:
         output_dir.mkdir(parents=True, exist_ok=True)
     except Exception as e:
-        logging.error(f"Failed to create output directory {output_dir}: {e}")
+        logger.error(f"Failed to create output directory {output_dir}: {e}")
         sys.exit(1)
 
     setup_logging(output_dir)
@@ -642,7 +645,7 @@ def main(
     # Default to hg19 and hg38 (UCSC) for backward compatibility
     if references_to_process is None:
         references_to_process = ["hg19", "hg38"]
-        logging.info("No references specified, using default: hg19, hg38")
+        logger.info("No references specified, using default: hg19, hg38")
 
     all_available_refs = (
         set(ucsc_refs.keys()) | set(ncbi_refs.keys()) | set(ensembl_refs.keys()) | set(vntyper_refs.keys())
@@ -652,14 +655,14 @@ def main(
     missing_refs = requested_refs - all_available_refs
 
     if missing_refs:
-        logging.warning(f"Requested references not found in config: {', '.join(sorted(missing_refs))}")
-        logging.warning(f"Available references: {', '.join(sorted(all_available_refs))}")
+        logger.warning(f"Requested references not found in config: {', '.join(sorted(missing_refs))}")
+        logger.warning(f"Available references: {', '.join(sorted(all_available_refs))}")
 
     if not found_refs:
-        logging.error("None of the requested references were found in the configuration.")
+        logger.error("None of the requested references were found in the configuration.")
         sys.exit(1)
 
-    logging.info(f"Processing references: {', '.join(sorted(found_refs))}")
+    logger.info(f"Processing references: {', '.join(sorted(found_refs))}")
 
     ucsc_refs = {k: v for k, v in ucsc_refs.items() if k in references_to_process}
     ncbi_refs = {k: v for k, v in ncbi_refs.items() if k in references_to_process}
@@ -669,10 +672,10 @@ def main(
     # Initialize aligners
     enabled_aligners = {}
     if not skip_indexing and aligner_config:
-        logging.info("=" * 80)
-        logging.info("ALIGNER CONFIGURATION")
-        logging.info("=" * 80)
-        logging.info("Checking available aligners:")
+        logger.info("=" * 80)
+        logger.info("ALIGNER CONFIGURATION")
+        logger.info("=" * 80)
+        logger.info("Checking available aligners:")
 
         # Get enabled aligners
         all_enabled = get_enabled_aligners(aligner_config)
@@ -683,46 +686,46 @@ def main(
                 if aligner_name in all_enabled:
                     enabled_aligners[aligner_name] = all_enabled[aligner_name]
                 elif aligner_name in aligner_config:
-                    logging.warning(f"  ✗ {aligner_name} was specified but is not available or not enabled")
+                    logger.warning(f"  ✗ {aligner_name} was specified but is not available or not enabled")
                 else:
-                    logging.error(f"  ✗ Unknown aligner: {aligner_name}")
+                    logger.error(f"  ✗ Unknown aligner: {aligner_name}")
         else:
             # Default to BWA only
             if "bwa" in all_enabled:
                 enabled_aligners["bwa"] = all_enabled["bwa"]
-                logging.info("  Using default aligner: bwa")
+                logger.info("  Using default aligner: bwa")
             else:
-                logging.warning("  Default aligner 'bwa' not available")
+                logger.warning("  Default aligner 'bwa' not available")
 
         if not enabled_aligners:
-            logging.warning("No aligners available. Indexing will be skipped.")
-            logging.warning(
+            logger.warning("No aligners available. Indexing will be skipped.")
+            logger.warning(
                 "To enable aligners, install them and ensure they are in your PATH, "
                 "or set enabled:true in install_references_config.json"
             )
         else:
-            logging.info(f"\nWill use {len(enabled_aligners)} aligner(s) for indexing:")
+            logger.info(f"\nWill use {len(enabled_aligners)} aligner(s) for indexing:")
             for name in enabled_aligners:
-                logging.info(f"  • {name}")
+                logger.info(f"  • {name}")
 
             # Detect index file conflicts
             conflicts = detect_index_conflicts(enabled_aligners)
             if conflicts:
-                logging.warning("\n⚠ Index file conflicts detected:")
+                logger.warning("\n⚠ Index file conflicts detected:")
                 for warning in conflicts:
-                    logging.warning(f"  • {warning}")
-                logging.warning("  These conflicts may cause issues if aligners overwrite each other's index files.")
+                    logger.warning(f"  • {warning}")
+                logger.warning("  These conflicts may cause issues if aligners overwrite each other's index files.")
             else:
-                logging.info("  ✓ No index file conflicts detected")
+                logger.info("  ✓ No index file conflicts detected")
 
-        logging.info("=" * 80)
-        logging.info("")
+        logger.info("=" * 80)
+        logger.info("")
 
     md5_dict: dict[str, str] = {}
 
     # Process UCSC references
     if ucsc_refs:
-        logging.info("Processing UCSC references...")
+        logger.info("Processing UCSC references...")
         process_ucsc_references(
             ucsc_refs,
             output_dir,
@@ -735,7 +738,7 @@ def main(
 
     # Process NCBI references
     if ncbi_refs:
-        logging.info("Processing NCBI references...")
+        logger.info("Processing NCBI references...")
         process_ucsc_references(
             ncbi_refs,
             output_dir,
@@ -748,7 +751,7 @@ def main(
 
     # Process ENSEMBL references
     if ensembl_refs:
-        logging.info("Processing ENSEMBL references...")
+        logger.info("Processing ENSEMBL references...")
         process_ucsc_references(
             ensembl_refs,
             output_dir,
@@ -761,12 +764,12 @@ def main(
 
     # Process VNtyper references
     if vntyper_refs:
-        logging.info("Processing VNtyper references...")
+        logger.info("Processing VNtyper references...")
         process_vntyper_references(vntyper_refs, output_dir, bwa_path, skip_indexing, md5_dict)
 
     # Process own repository references
     if own_repo_refs:
-        logging.info("Processing own repository references...")
+        logger.info("Processing own repository references...")
         process_own_repository_references(own_repo_refs, output_dir, skip_indexing, md5_dict)
 
     # Write MD5 checksums to file
@@ -817,11 +820,11 @@ def main(
         update_config(config_path, updated_references)
     else:
         if config_path:
-            logging.warning(f"Config file {config_path} does not exist. Skipping config update.")
+            logger.warning(f"Config file {config_path} does not exist. Skipping config update.")
         else:
-            logging.info("No config_path provided. Skipping config update.")
+            logger.info("No config_path provided. Skipping config update.")
 
-    logging.info("All references have been installed and configured successfully.")
+    logger.info("All references have been installed and configured successfully.")
 
 
 if __name__ == "__main__":

--- a/vntyper/scripts/kestrel_genotyping.py
+++ b/vntyper/scripts/kestrel_genotyping.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 kestrel_genotyping.py
 
@@ -27,7 +26,7 @@ from Saei et al., iScience 26, 107171 (2023).
 import logging
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -55,6 +54,8 @@ from vntyper.scripts.variant_parsing import (
     read_vcf_without_comments,
 )
 from vntyper.version import __version__ as VERSION
+
+logger = logging.getLogger(__name__)
 
 
 def load_kestrel_config(config_path=None):
@@ -164,7 +165,7 @@ def generate_header(reference_vntr, version=VERSION):
     header = [
         "## VNtyper Kestrel result",
         f"## VNtyper Version: {version}",
-        f"## Analysis date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        f"## Analysis date: {datetime.now(timezone.utc).astimezone().strftime('%Y-%m-%d %H:%M:%S')}",
         f"## Reference file: {reference_vntr}",
     ]
     return header
@@ -186,14 +187,14 @@ def convert_sam_to_bam_and_index(sam_file, output_dir):
     bam_index = bam_file + ".bai"
 
     # Convert SAM to BAM using samtools
-    logging.info(f"Converting SAM to BAM: {sam_file} -> {bam_file}")
+    logger.info(f"Converting SAM to BAM: {sam_file} -> {bam_file}")
     run_command(
         f"samtools view -Sb {sam_file} > {bam_file}",
         log_file=os.path.join(output_dir, "samtools_view.log"),
     )
 
     # Index the BAM file
-    logging.info(f"Indexing BAM file: {bam_file}")
+    logger.info(f"Indexing BAM file: {bam_file}")
     run_command(
         f"samtools index {bam_file}",
         log_file=os.path.join(output_dir, "samtools_index.log"),
@@ -202,7 +203,7 @@ def convert_sam_to_bam_and_index(sam_file, output_dir):
     # Delete the SAM file if indexing succeeds
     if os.path.exists(bam_file) and os.path.exists(bam_index):
         os.remove(sam_file)
-        logging.info(f"Deleted SAM file: {sam_file}")
+        logger.info(f"Deleted SAM file: {sam_file}")
 
     return bam_file
 
@@ -250,8 +251,6 @@ def run_kestrel(
     Returns:
         None
     """
-    global kestrel_config  # Use globally loaded Kestrel config
-
     kestrel_settings = kestrel_config.get("kestrel_settings", {})
     java_path = config["tools"]["java_path"]
     java_memory = kestrel_settings.get("java_memory", "12g")
@@ -286,17 +285,17 @@ def run_kestrel(
 
         # If the final VCF already exists, skip new runs
         if vcf_path.is_file():
-            logging.info("VCF file already exists, skipping Kestrel run...")
+            logger.info("VCF file already exists, skipping Kestrel run...")
             return
         else:
-            logging.info(f"Launching Kestrel with k-mer size {kmer_size}...")
+            logger.info(f"Launching Kestrel with k-mer size {kmer_size}...")
 
             # Actually run the Kestrel command
             if not run_command(kmer_command, log_file, critical=True, cwd=cwd):
-                logging.error(f"Kestrel failed for k-mer size {kmer_size}. Check {log_file} for details.")
+                logger.error(f"Kestrel failed for k-mer size {kmer_size}. Check {log_file} for details.")
                 raise RuntimeError(f"Kestrel failed for kmer size {kmer_size}.")
 
-            logging.info(f"Mapping-free genotyping of MUC1-VNTR with k-mer size {kmer_size} done!")
+            logger.info(f"Mapping-free genotyping of MUC1-VNTR with k-mer size {kmer_size} done!")
 
             # Now that Kestrel completed, confirm the VCF is present
             if vcf_path.is_file():
@@ -332,7 +331,7 @@ def _try_compress_vcf_with_bcftools(input_vcf, output_vcf_gz, output_dir):
     """
     # Check if bcftools is available (defensive programming)
     if shutil.which("bcftools") is None:
-        logging.warning(
+        logger.warning(
             "bcftools not found in PATH. VCF compression skipped. "
             "IGV report will use uncompressed VCF. "
             "For optimal performance, install bcftools: 'conda install bcftools'"
@@ -347,12 +346,12 @@ def _try_compress_vcf_with_bcftools(input_vcf, output_vcf_gz, output_dir):
     )
 
     if not success:
-        logging.error(
+        logger.error(
             f"bcftools sort command failed. Check {log_file} for details. IGV report will use uncompressed VCF."
         )
         return False
 
-    logging.info(f"VCF successfully compressed: {output_vcf_gz}")
+    logger.info(f"VCF successfully compressed: {output_vcf_gz}")
     return True
 
 
@@ -381,7 +380,7 @@ def process_kestrel_output(output_dir, vcf_path, reference_vntr, kestrel_config,
         pd.DataFrame or None:
           The final processed DataFrame of variants, or None if no variants found.
     """
-    logging.info("Processing Kestrel VCF results...")
+    logger.info("Processing Kestrel VCF results...")
 
     # Step 1) Filter the original VCF to extract INDELs
     indel_vcf = os.path.join(output_dir, "output_indel.vcf")
@@ -416,7 +415,7 @@ def process_kestrel_output(output_dir, vcf_path, reference_vntr, kestrel_config,
 
     # If both are empty, produce an empty result file
     if vcf_insertion.empty and vcf_deletion.empty:
-        logging.warning("No insertion/deletion variants found. Skipping.")
+        logger.warning("No insertion/deletion variants found. Skipping.")
         output_empty_result(output_dir, header)
         return None
 
@@ -433,7 +432,7 @@ def process_kestrel_output(output_dir, vcf_path, reference_vntr, kestrel_config,
     combined_df = combined_df.sort_values(by=sort_columns).reset_index(drop=True)
 
     if combined_df.empty:
-        logging.warning("Empty combined DataFrame of insertions+deletions.")
+        logger.warning("Empty combined DataFrame of insertions+deletions.")
         output_empty_result(output_dir, header)
         return None
 
@@ -444,7 +443,7 @@ def process_kestrel_output(output_dir, vcf_path, reference_vntr, kestrel_config,
     processed_df = process_kmer_results(combined_df, merged_motifs, output_dir, kestrel_config)
 
     if processed_df.empty:
-        logging.warning("Final processed DataFrame is empty. Writing empty result.")
+        logger.warning("Final processed DataFrame is empty. Writing empty result.")
         output_empty_result(output_dir, header)
         return None
 
@@ -467,7 +466,7 @@ def process_kestrel_output(output_dir, vcf_path, reference_vntr, kestrel_config,
         f.write("\n".join(header) + "\n")
         processed_df.to_csv(f, sep="\t", index=False)
 
-    logging.info("Kestrel VCF processing completed.")
+    logger.info("Kestrel VCF processing completed.")
     return processed_df
 
 
@@ -501,7 +500,7 @@ def output_empty_result(output_dir, header):
         f.write("\n".join(header) + "\n")
         empty_df.to_csv(f, sep="\t", index=False)
 
-    logging.info(f"Empty result file with placeholder saved at {final_output_path}")
+    logger.info(f"Empty result file with placeholder saved at {final_output_path}")
 
 
 def process_kmer_results(combined_df, merged_motifs, output_dir, kestrel_config):
@@ -586,13 +585,13 @@ def process_kmer_results(combined_df, merged_motifs, output_dir, kestrel_config)
     # (7) Final Filter
     df = filter_final_dataframe(df, output_dir)
     if df.empty:
-        logging.info("All rows failed one or more filter criteria. Returning empty.")
+        logger.info("All rows failed one or more filter criteria. Returning empty.")
         return df
 
     # (8) Now generate the BED file from the fully filtered result
     bed_file_path = generate_bed_file(df, output_dir)
     if bed_file_path:
-        logging.info(f"BED file created at: {bed_file_path}")
+        logger.info(f"BED file created at: {bed_file_path}")
 
     return df
 
@@ -612,11 +611,11 @@ def generate_bed_file(df, output_dir):
     """
     # We only generate a BED if columns 'Motif_fasta' & 'POS_fasta' exist
     if "Motif_fasta" not in df.columns or "POS_fasta" not in df.columns:
-        logging.warning("Missing 'Motif_fasta' or 'POS_fasta' in DataFrame. Skipping BED file generation.")
+        logger.warning("Missing 'Motif_fasta' or 'POS_fasta' in DataFrame. Skipping BED file generation.")
         return None
 
     if df.empty:
-        logging.warning("DataFrame is empty. No variants to generate a BED file.")
+        logger.warning("DataFrame is empty. No variants to generate a BED file.")
         return None
 
     bed_file_path = os.path.join(output_dir, "output.bed")
@@ -628,7 +627,7 @@ def generate_bed_file(df, output_dir):
             pos = row["POS_fasta"]
             bed_file.write(f"{motif_fasta}\t{pos}\t{pos + 1}\n")
 
-    logging.info(f"BED file generated at: {bed_file_path}")
+    logger.info(f"BED file generated at: {bed_file_path}")
     return bed_file_path
 
 
@@ -664,7 +663,7 @@ def add_haplo_count(df: pd.DataFrame) -> pd.DataFrame:
     if all(col in df.columns for col in ["POS", "REF", "ALT"]):
         df["haplo_count"] = df.groupby(["POS", "REF", "ALT"])["ALT"].transform("size")
     else:
-        logging.warning("Missing POS/REF/ALT columns for haplo_count calculation")
+        logger.warning("Missing POS/REF/ALT columns for haplo_count calculation")
         df["haplo_count"] = 0
 
     return df
@@ -756,7 +755,7 @@ def select_single_best_variant(df: pd.DataFrame) -> pd.DataFrame:
     # Keep only the best variant
     result = df.head(1).drop(columns=["_priority", "_is_unflagged"])
 
-    logging.info(
+    logger.info(
         "Selected best variant: Confidence=%s, haplo_count=%d, Depth_Score=%.5f, POS=%d",
         result.iloc[0]["Confidence"],
         int(result.iloc[0]["haplo_count"]),
@@ -789,12 +788,12 @@ def filter_final_dataframe(df: pd.DataFrame, output_dir: str) -> pd.DataFrame:
         pd.DataFrame: A copy of `df` containing only rows that pass
             all available filter columns.
     """
-    logging.info("Starting final filter of DataFrame with %d rows...", len(df))
+    logger.info("Starting final filter of DataFrame with %d rows...", len(df))
 
     # Write the unfiltered DataFrame to 'kestrel_pre_result.tsv' in output_dir
     pre_result_path = os.path.join(output_dir, "kestrel_pre_result.tsv")
     df.to_csv(pre_result_path, sep="\t", index=False)
-    logging.info("Wrote pre-filter DataFrame to %s", pre_result_path)
+    logger.info("Wrote pre-filter DataFrame to %s", pre_result_path)
 
     # Columns we will require to be True if they exist
     filter_cols = [
@@ -812,25 +811,25 @@ def filter_final_dataframe(df: pd.DataFrame, output_dir: str) -> pd.DataFrame:
             before_count = final_mask.sum()
             final_mask &= df[col]
             after_count = final_mask.sum()
-            logging.info(
+            logger.info(
                 "Filter column '%s' exists; %d -> %d rows remain after requiring True.",
                 col,
                 before_count,
                 after_count,
             )
         else:
-            logging.info("Filter column '%s' not found; skipping.", col)
+            logger.info("Filter column '%s' not found; skipping.", col)
 
     filtered_df = df[final_mask].copy()
-    logging.info("Final DataFrame has %d rows after all filters.", len(filtered_df))
+    logger.info("Final DataFrame has %d rows after all filters.", len(filtered_df))
 
     # Select single best variant using multi-key priority sorting
     if len(filtered_df) > 1:
         filtered_df = select_single_best_variant(filtered_df)
-        logging.info("Selected 1 best variant from %d candidates using priority sorting.", len(df[final_mask]))
+        logger.info("Selected 1 best variant from %d candidates using priority sorting.", len(df[final_mask]))
     elif len(filtered_df) == 1:
-        logging.info("Only 1 variant passed all filters (no selection needed).")
+        logger.info("Only 1 variant passed all filters (no selection needed).")
     else:
-        logging.info("No variants passed all filters.")
+        logger.info("No variants passed all filters.")
 
     return filtered_df

--- a/vntyper/scripts/motif_processing.py
+++ b/vntyper/scripts/motif_processing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/scripts/motif_processing.py
 
 """
@@ -30,6 +29,8 @@ import logging
 
 import pandas as pd
 from Bio import SeqIO
+
+logger = logging.getLogger(__name__)
 
 
 def load_muc1_reference(reference_file):
@@ -294,11 +295,11 @@ def motif_correction_and_annotation(df, merged_motifs, kestrel_config):
       - Default: false (legacy behavior for backward compatibility)
       - When true: applies depth-score-based filtering (fixes insG_pos54 detection)
     """
-    logging.debug("Entering motif_correction_and_annotation")
-    logging.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Entering motif_correction_and_annotation")
+    logger.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
 
     if df.empty:
-        logging.debug("DataFrame is empty. Exiting motif_correction_and_annotation.")
+        logger.debug("DataFrame is empty. Exiting motif_correction_and_annotation.")
         df["motif_filter_pass"] = False
         df["Motif_fasta"] = pd.NA
         df["POS_fasta"] = pd.NA
@@ -325,12 +326,11 @@ def motif_correction_and_annotation(df, merged_motifs, kestrel_config):
     if "Motifs" in working_df.columns:
         working_df["Motif_fasta"] = working_df["Motifs"]
     else:
-        logging.error("Missing 'Motifs' column. Old code returns empty.")
+        logger.error("Missing 'Motifs' column. Old code returns empty.")
         combined_df = pd.DataFrame(columns=working_df.columns)
-        pass
 
     if "Motifs" not in working_df.columns or working_df["Motifs"].str.count("-").max() != 1:
-        logging.error("Cannot split 'Motifs' into left-right. Old code returns empty.")
+        logger.error("Cannot split 'Motifs' into left-right. Old code returns empty.")
         combined_df = pd.DataFrame(columns=working_df.columns)
     else:
         working_df[["Motif_left", "Motif_right"]] = working_df["Motifs"].str.split("-", expand=True)
@@ -458,6 +458,6 @@ def motif_correction_and_annotation(df, merged_motifs, kestrel_config):
     # Drop the temporary original_index column
     original_df.drop(columns=["original_index"], inplace=True, errors="ignore")
 
-    logging.debug("Exiting motif_correction_and_annotation")
-    logging.debug(f"Final row count: {len(original_df)}, columns: {original_df.columns.tolist()}")
+    logger.debug("Exiting motif_correction_and_annotation")
+    logger.debug(f"Final row count: {len(original_df)}, columns: {original_df.columns.tolist()}")
     return original_df

--- a/vntyper/scripts/online_mode.py
+++ b/vntyper/scripts/online_mode.py
@@ -7,6 +7,8 @@ import requests
 
 from vntyper.scripts.region_utils import get_region_string_with_fallback
 
+logger = logging.getLogger(__name__)
+
 
 def subset_bam(bam_path, region, output_bam):
     """
@@ -21,15 +23,15 @@ def subset_bam(bam_path, region, output_bam):
         RuntimeError: If subset or indexing fails.
     """
     cmd = ["samtools", "view", "-P", "-b", bam_path, region, "-o", output_bam]
-    logging.info(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    logger.info(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         raise RuntimeError(f"Failed to subset BAM: {result.stderr}")
 
     # Index the subset bam
     cmd_index = ["samtools", "index", output_bam]
-    logging.info(f"Running: {' '.join(cmd_index)}")
-    result_idx = subprocess.run(cmd_index, capture_output=True, text=True)
+    logger.info(f"Running: {' '.join(cmd_index)}")
+    result_idx = subprocess.run(cmd_index, capture_output=True, text=True, check=False)
     if result_idx.returncode != 0:
         raise RuntimeError(f"Failed to index subset BAM: {result_idx.stderr}")
 
@@ -78,7 +80,7 @@ def submit_job(
         data["passphrase"] = passphrase
 
     submit_url = f"{api_url}/run-job/"
-    logging.info(f"Submitting job to {submit_url}")
+    logger.info(f"Submitting job to {submit_url}")
 
     with open(subset_bam, "rb") as bam_file:
         files = {"bam_file": ("subset.bam", bam_file, "application/octet-stream")}
@@ -110,7 +112,7 @@ def poll_job_status(api_url, job_id):
     """
     status_url = f"{api_url}/job-status/{job_id}/"
     while True:
-        logging.info(f"Checking job status for {job_id}")
+        logger.info(f"Checking job status for {job_id}")
         resp = requests.get(status_url, timeout=30)
         if resp.status_code != 200:
             raise RuntimeError(f"Failed to get job status. Status: {resp.status_code}, Detail: {resp.text}")
@@ -118,7 +120,7 @@ def poll_job_status(api_url, job_id):
         status = data.get("status", "")
         if status in ["completed", "failed"]:
             return status
-        logging.info(f"Job {job_id} status: {status}, waiting...")
+        logger.info(f"Job {job_id} status: {status}, waiting...")
         time.sleep(10)
 
 
@@ -135,14 +137,14 @@ def download_results(api_url, job_id, output_dir):
         RuntimeError: If download fails.
     """
     dl_url = f"{api_url}/download/{job_id}/"
-    logging.info(f"Downloading results from {dl_url}")
+    logger.info(f"Downloading results from {dl_url}")
     resp = requests.get(dl_url, timeout=60)
     if resp.status_code != 200:
         raise RuntimeError(f"Failed to download results. Status: {resp.status_code}, Detail: {resp.text}")
     zip_path = output_dir / f"{job_id}.zip"
     with open(zip_path, "wb") as f:
         f.write(resp.content)
-    logging.info(f"Results saved to {zip_path}")
+    logger.info(f"Results saved to {zip_path}")
 
 
 def run_online_mode(
@@ -194,9 +196,9 @@ def run_online_mode(
         status = poll_job_status(api_url, job_id)
         if status == "completed":
             download_results(api_url, job_id, output_path)
-            logging.info("Job completed successfully.")
+            logger.info("Job completed successfully.")
         else:
-            logging.error("Job failed or status unknown.")
+            logger.error("Job failed or status unknown.")
         return
 
     # Fresh submission
@@ -216,7 +218,7 @@ def run_online_mode(
     )
     job_id = resp.get("job_id")
     if not job_id:
-        logging.error("No job_id returned from API.")
+        logger.error("No job_id returned from API.")
         return
 
     with open(job_id_file, "w") as f:
@@ -226,6 +228,6 @@ def run_online_mode(
     status = poll_job_status(api_url, job_id)
     if status == "completed":
         download_results(api_url, job_id, output_path)
-        logging.info("Job completed successfully.")
+        logger.info("Job completed successfully.")
     else:
-        logging.error("Job failed or status unknown.")
+        logger.error("Job failed or status unknown.")

--- a/vntyper/scripts/pipeline.py
+++ b/vntyper/scripts/pipeline.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/scripts/pipeline.py
 
 import logging
@@ -6,7 +5,7 @@ import os
 import shutil
 import sys
 import timeit
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from vntyper.scripts.alignment_processing import align_and_sort_fastq
@@ -46,6 +45,8 @@ from vntyper.scripts.utils import (
 )
 from vntyper.version import __version__ as VERSION
 
+logger = logging.getLogger(__name__)
+
 
 def write_bed_file(regions, bed_file_path):
     """
@@ -62,7 +63,7 @@ def write_bed_file(regions, bed_file_path):
                 start, end = positions.strip().split("-")
                 bed_fh.write(f"{chrom}\t{start}\t{end}\n")
             except ValueError as e:
-                logging.error(f"Invalid region format: {region}. Expected format 'chr:start-end'.")
+                logger.error(f"Invalid region format: {region}. Expected format 'chr:start-end'.")
                 raise ValueError(f"Invalid region format: {region}. Expected format 'chr:start-end'.") from e
 
 
@@ -93,18 +94,18 @@ def _select_best_vcf_file(kestrel_dir):
     vcf = os.path.join(kestrel_dir, "output_indel.vcf")
 
     if os.path.exists(vcf_gz):
-        logging.debug(f"Using compressed VCF for IGV report: {vcf_gz}")
+        logger.debug(f"Using compressed VCF for IGV report: {vcf_gz}")
         return vcf_gz
 
     if os.path.exists(vcf):
-        logging.info(
+        logger.info(
             f"Using uncompressed VCF for IGV report: {vcf}. "
             "Compressed VCF not available (bcftools may not be installed)."
         )
         return vcf
 
     # Neither file exists - this is unusual and should be logged
-    logging.warning(
+    logger.warning(
         f"No VCF file found in {kestrel_dir}. "
         "IGV report will be generated without VCF track. "
         "Expected files: output_indel.vcf.gz or output_indel.vcf"
@@ -173,27 +174,27 @@ def run_pipeline(
     # throughout the pipeline execution, especially for tools like Java that need it
     try:
         project_root = os.getcwd()
-        logging.debug(f"Captured project root directory: {project_root}")
+        logger.debug(f"Captured project root directory: {project_root}")
     except (OSError, FileNotFoundError) as e:
         # If we can't get the current directory, try to use the absolute path of the script
         project_root = str(Path(__file__).parent.parent.parent)
-        logging.warning(f"Could not determine current working directory ({e}), using fallback: {project_root}")
+        logger.warning(f"Could not determine current working directory ({e}), using fallback: {project_root}")
 
     if not bwa_reference:
-        logging.error("BWA reference not provided or determined from configuration.")
+        logger.error("BWA reference not provided or determined from configuration.")
         raise ValueError("BWA reference not provided or determined from configuration.")
 
-    logging.debug(f"BWA reference set to: {bwa_reference}")
-    logging.debug(f"Output directory set to: {output_dir}")
+    logger.debug(f"BWA reference set to: {bwa_reference}")
+    logger.debug(f"Output directory set to: {output_dir}")
 
     dirs = create_output_directories(output_dir)
-    logging.info(f"Created output directories in: {output_dir}")
+    logger.info(f"Created output directories in: {output_dir}")
 
     tool_versions = get_tool_versions(config)
-    logging.info(f"VNtyper pipeline {VERSION} started with tool versions: {tool_versions}")
+    logger.info(f"VNtyper pipeline {VERSION} started with tool versions: {tool_versions}")
 
     overall_start = timeit.default_timer()
-    logging.info("Pipeline execution started.")
+    logger.info("Pipeline execution started.")
 
     # Initialize summary to record pipeline steps, including vntyper version and empty input_files.
     summary = start_summary(version=VERSION, input_files={})
@@ -208,7 +209,7 @@ def run_pipeline(
     elif cram:
         input_type = "CRAM"
     else:
-        logging.error("No input files provided.")
+        logger.error("No input files provided.")
         raise ValueError("No input files provided.")
 
     input_files = {}
@@ -231,11 +232,11 @@ def run_pipeline(
             ]
         )
         if input_count > 1:
-            logging.error("Multiple input types provided. Provide only one: FASTQ, BAM, or CRAM.")
+            logger.error("Multiple input types provided. Provide only one: FASTQ, BAM, or CRAM.")
             raise ValueError("Provide either BAM, CRAM, or FASTQ files, not multiples.")
 
         if not bam and not cram and (not fastq1 or not fastq2):
-            logging.error(
+            logger.error(
                 "When not providing BAM/CRAM, both --fastq1 and --fastq2 must be specified for paired-end sequencing."
             )
             raise ValueError(
@@ -251,18 +252,18 @@ def run_pipeline(
             validate_fastq_file(fastq1)
             validate_fastq_file(fastq2)
         else:
-            logging.error("Incomplete FASTQ inputs provided.")
+            logger.error("Incomplete FASTQ inputs provided.")
             raise ValueError("Both FASTQ files must be provided for paired-end sequencing.")  # BED file logic
         if bed_file:
             bed_file_path = Path(bed_file)
             if not bed_file_path.exists():
-                logging.error(f"Provided BED file does not exist: {bed_file_path}")
+                logger.error(f"Provided BED file does not exist: {bed_file_path}")
                 raise FileNotFoundError(f"BED file not found: {bed_file_path}")
-            logging.info(f"Using provided BED file: {bed_file_path}")
+            logger.info(f"Using provided BED file: {bed_file_path}")
         elif custom_regions:
             bed_file_path = Path(output_dir) / "custom_regions.bed"
             write_bed_file(custom_regions, bed_file_path)
-            logging.info(f"Custom regions converted to BED file: {bed_file_path}")
+            logger.info(f"Custom regions converted to BED file: {bed_file_path}")
         else:
             # Use dynamic region resolution for BAM/CRAM, fallback to legacy for FASTQ
             if input_type in ["BAM", "CRAM"]:
@@ -275,23 +276,23 @@ def run_pipeline(
                 region_key = f"bam_region_{reference_assembly}"
                 predefined_regions = config.get("bam_processing", {}).get(region_key)
                 if not predefined_regions:
-                    logging.error(f"Region key '{region_key}' not found in config.json under 'bam_processing'.")
+                    logger.error(f"Region key '{region_key}' not found in config.json under 'bam_processing'.")
                     raise ValueError(f"Missing configuration for region: {region_key}")
 
             bed_file_path = Path(output_dir) / f"predefined_regions_{reference_assembly}.bed"
             write_bed_file(predefined_regions, bed_file_path)
-            logging.info(f"Predefined regions converted to BED file: {bed_file_path}")
+            logger.info(f"Predefined regions converted to BED file: {bed_file_path}")
 
-        logging.debug(f"Final bed_file_path => {bed_file_path}")
-        logging.debug(f"bed_file_path exists? {bed_file_path.exists()}")
+        logger.debug(f"Final bed_file_path => {bed_file_path}")
+        logger.debug(f"bed_file_path exists? {bed_file_path.exists()}")
 
         # --- Input Conversion ---
         if input_type in ["BAM", "CRAM"]:
-            logging.info(f"Starting {input_type} to FASTQ conversion with specified regions.")
-            conversion_start = datetime.utcnow()
+            logger.info(f"Starting {input_type} to FASTQ conversion with specified regions.")
+            conversion_start = datetime.now(timezone.utc).replace(tzinfo=None)
             if input_type == "BAM":
                 if bam is None or str(bam).strip().lower() == "none":
-                    logging.error("Invalid BAM input (None).")
+                    logger.error("Invalid BAM input (None).")
                     raise ValueError("Invalid BAM file input.")
 
                 fastq1, fastq2, _, _ = process_bam_to_fastq(
@@ -307,10 +308,10 @@ def run_pipeline(
                     bed_file=bed_file_path,
                 )
                 conversion_command = f"process_bam_to_fastq(in_bam={bam}, ...)"
-                header_parse_start = datetime.utcnow()
+                header_parse_start = datetime.now(timezone.utc).replace(tzinfo=None)
                 header = extract_bam_header(bam, config)
                 parse_header_pipeline_info(header, Path(dirs["fastq_bam_processing"]), config)
-                header_parse_end = datetime.utcnow()
+                header_parse_end = datetime.now(timezone.utc).replace(tzinfo=None)
                 record_step(
                     summary,
                     "BAM Header Parsing",
@@ -323,7 +324,7 @@ def run_pipeline(
                 )
             else:  # CRAM branch
                 if cram is None or str(cram).strip().lower() == "none":
-                    logging.error("Invalid CRAM input (None).")
+                    logger.error("Invalid CRAM input (None).")
                     raise ValueError("Invalid CRAM file input.")
 
                 fastq1, fastq2, _, _ = process_bam_to_fastq(
@@ -340,7 +341,7 @@ def run_pipeline(
                     file_format="cram",
                 )
                 conversion_command = f"process_bam_to_fastq(in_bam={cram}, file_format='cram', ...)"
-            conversion_end = datetime.utcnow()
+            conversion_end = datetime.now(timezone.utc).replace(tzinfo=None)
             record_step(
                 summary,
                 f"{input_type} to FASTQ Conversion",
@@ -352,7 +353,7 @@ def run_pipeline(
                 write_summary_path=summary_file_path,
             )
             if not fastq1 or not fastq2:
-                logging.error("Failed to generate FASTQ files from input. Exiting.")
+                logger.error("Failed to generate FASTQ files from input. Exiting.")
                 raise ValueError("Failed to generate FASTQ files from input.")
 
         elif input_type == "FASTQ":
@@ -364,9 +365,9 @@ def run_pipeline(
                 )
 
                 shark_config = load_shark_config()
-                logging.info("SHARK module included. Running SHARK filtering first.")
-                run_sample_name = sample_name if sample_name else "sample"
-                shark_start = datetime.utcnow()
+                logger.info("SHARK module included. Running SHARK filtering first.")
+                run_sample_name = sample_name or "sample"
+                shark_start = datetime.now(timezone.utc).replace(tzinfo=None)
                 fastq1, fastq2 = run_shark_filter(
                     fastq_1=fastq1,
                     fastq_2=fastq2,
@@ -377,7 +378,7 @@ def run_pipeline(
                     reference_assembly=reference_assembly,
                     threads=threads,
                 )
-                shark_end = datetime.utcnow()
+                shark_end = datetime.now(timezone.utc).replace(tzinfo=None)
                 record_step(
                     summary,
                     "SHARK Filtering",
@@ -388,8 +389,8 @@ def run_pipeline(
                     shark_end,
                     write_summary_path=summary_file_path,
                 )
-            logging.info("Starting FASTQ quality control.")
-            qc_start = datetime.utcnow()
+            logger.info("Starting FASTQ quality control.")
+            qc_start = datetime.now(timezone.utc).replace(tzinfo=None)
             process_fastq(
                 fastq1,
                 fastq2,
@@ -398,7 +399,7 @@ def run_pipeline(
                 "output",
                 config,
             )
-            qc_end = datetime.utcnow()
+            qc_end = datetime.now(timezone.utc).replace(tzinfo=None)
             record_step(
                 summary,
                 "FASTQ Quality Control",
@@ -409,11 +410,11 @@ def run_pipeline(
                 qc_end,
                 write_summary_path=summary_file_path,
             )
-            logging.info("FASTQ quality control completed.")
+            logger.info("FASTQ quality control completed.")
             fastq1 = os.path.join(dirs["fastq_bam_processing"], "output_R1.fastq.gz")
             fastq2 = os.path.join(dirs["fastq_bam_processing"], "output_R2.fastq.gz")
-            logging.info("Starting FASTQ alignment.")
-            align_start = datetime.utcnow()
+            logger.info("Starting FASTQ alignment.")
+            align_start = datetime.now(timezone.utc).replace(tzinfo=None)
             sorted_bam = align_and_sort_fastq(
                 fastq1,
                 fastq2,
@@ -423,7 +424,7 @@ def run_pipeline(
                 threads,
                 config,
             )
-            align_end = datetime.utcnow()
+            align_end = datetime.now(timezone.utc).replace(tzinfo=None)
             record_step(
                 summary,
                 "FASTQ Alignment",
@@ -435,15 +436,15 @@ def run_pipeline(
                 write_summary_path=summary_file_path,
             )
             if not sorted_bam:
-                logging.error(
+                logger.error(
                     "Alignment failed: BWA index files for the provided reference "
                     "are missing or incomplete. Please run 'bwa index <reference.fa>' "
                     "to generate them."
                 )
                 raise RuntimeError("Alignment failed due to missing or incomplete BWA reference indices.")
-            logging.info("FASTQ alignment completed.")
-            logging.info("Starting BAM to FASTQ conversion (Post-alignment).")
-            conv2_start = datetime.utcnow()
+            logger.info("FASTQ alignment completed.")
+            logger.info("Starting BAM to FASTQ conversion (Post-alignment).")
+            conv2_start = datetime.now(timezone.utc).replace(tzinfo=None)
             fastq1, fastq2, _, _ = process_bam_to_fastq(
                 in_bam=sorted_bam,
                 output=dirs["fastq_bam_processing"],
@@ -456,7 +457,7 @@ def run_pipeline(
                 keep_intermediates=keep_intermediates,
                 bed_file=bed_file_path,
             )
-            conv2_end = datetime.utcnow()
+            conv2_end = datetime.now(timezone.utc).replace(tzinfo=None)
             record_step(
                 summary,
                 "BAM to FASTQ Conversion (Post-alignment)",
@@ -468,9 +469,9 @@ def run_pipeline(
                 write_summary_path=summary_file_path,
             )
             if not fastq1 or not fastq2:
-                logging.error("Failed to generate FASTQ files from BAM. Exiting.")
+                logger.error("Failed to generate FASTQ files from BAM. Exiting.")
                 raise ValueError("Failed to generate FASTQ files from BAM.")  # --- Coverage Calculation ---
-        logging.info("Calculating mean coverage over the VNTR region.")
+        logger.info("Calculating mean coverage over the VNTR region.")
         if input_type == "BAM":
             input_bam = Path(bam)
         elif input_type == "CRAM":
@@ -483,7 +484,7 @@ def run_pipeline(
             bam_file=str(input_bam), reference_assembly=reference_assembly, region_type="vntr_region", config=config
         )
 
-        cov_start = datetime.utcnow()
+        cov_start = datetime.now(timezone.utc).replace(tzinfo=None)
         calculate_vntr_coverage(
             bam_file=str(input_bam),
             region=vntr_region,
@@ -492,7 +493,7 @@ def run_pipeline(
             output_dir=dirs["coverage"],
             output_name="coverage",
         )
-        cov_end = datetime.utcnow()
+        cov_end = datetime.now(timezone.utc).replace(tzinfo=None)
         record_step(
             summary,
             "Coverage Calculation",
@@ -505,12 +506,12 @@ def run_pipeline(
         )
 
         # --- Kestrel Genotyping ---
-        logging.info("Starting Kestrel genotyping.")
+        logger.info("Starting Kestrel genotyping.")
         vcf_out = os.path.join(dirs["kestrel"], "output.vcf")
         kestrel_path = config["tools"]["kestrel"]
         reference_vntr = config["reference_data"]["muc1_reference_vntr"]
 
-        kestrel_start = datetime.utcnow()
+        kestrel_start = datetime.now(timezone.utc).replace(tzinfo=None)
         if fastq1 and fastq2:
             run_kestrel(
                 vcf_path=Path(vcf_out),
@@ -525,9 +526,9 @@ def run_pipeline(
                 cwd=project_root,
             )
         else:
-            logging.error("FASTQ files required for Kestrel genotyping not provided.")
+            logger.error("FASTQ files required for Kestrel genotyping not provided.")
             raise ValueError("FASTQ files required for Kestrel genotyping not provided.")
-        kestrel_end = datetime.utcnow()
+        kestrel_end = datetime.now(timezone.utc).replace(tzinfo=None)
         record_step(
             summary,
             "Kestrel Genotyping",
@@ -538,11 +539,11 @@ def run_pipeline(
             kestrel_end,
             write_summary_path=summary_file_path,
         )
-        logging.info(
+        logger.info(
             "Kestrel genotyping completed."
         )  # --- adVNTR Genotyping and Cross-Match (only if advntr requested and performed) ---
         if "advntr" in extra_modules:
-            logging.info("adVNTR module included. Starting adVNTR genotyping.")
+            logger.info("adVNTR module included. Starting adVNTR genotyping.")
             try:
                 from vntyper.modules.advntr.advntr_genotyping import (
                     load_advntr_config,
@@ -550,7 +551,7 @@ def run_pipeline(
                     run_advntr,
                 )
             except ImportError as exc:
-                logging.error(f"adVNTR module import failed: {exc}")
+                logger.error(f"adVNTR module import failed: {exc}")
                 sys.exit(1)
 
             advntr_config = load_advntr_config()
@@ -573,20 +574,20 @@ def run_pipeline(
                 elif advntr_reference == "hg38":
                     advntr_reference = config.get("reference_data", {}).get("advntr_reference_vntr_hg38")
                 else:
-                    logging.error(f"Invalid advntr_reference: {advntr_reference}")
+                    logger.error(f"Invalid advntr_reference: {advntr_reference}")
                     raise ValueError(f"Invalid advntr_reference: {advntr_reference}")
 
             if not advntr_reference:
-                logging.error("adVNTR reference path not found in configuration.")
+                logger.error("adVNTR reference path not found in configuration.")
                 raise ValueError("adVNTR reference path not found in configuration.")
 
-            logging.debug(f"adVNTR reference set to: {advntr_reference}")
+            logger.debug(f"adVNTR reference set to: {advntr_reference}")
 
             max_cov = module_args.get("advntr", {}).get("max_coverage")
             sorted_bam = Path(dirs["fastq_bam_processing"]) / "output_sliced.bam"
             if sorted_bam and sorted_bam.exists():
                 if max_cov:
-                    logging.info(f"Using quick adVNTR mode with max coverage = {max_cov}")
+                    logger.info(f"Using quick adVNTR mode with max coverage = {max_cov}")
                     sorted_bam = downsample_bam_if_needed(
                         bam_path=sorted_bam,
                         max_coverage=max_cov,
@@ -596,7 +597,7 @@ def run_pipeline(
                         coverage_dir=dirs["coverage"],
                         coverage_prefix="advntr_precheck",
                     )
-                advntr_start = datetime.utcnow()
+                advntr_start = datetime.now(timezone.utc).replace(tzinfo=None)
                 run_advntr(
                     advntr_reference,
                     sorted_bam,
@@ -609,7 +610,7 @@ def run_pipeline(
                 output_ext = ".vcf" if output_format == "vcf" else ".tsv"
                 output_path = os.path.join(dirs["advntr"], f"output_adVNTR{output_ext}")
                 process_advntr_output(output_path, dirs["advntr"], "output", config=config)
-                advntr_end = datetime.utcnow()
+                advntr_end = datetime.now(timezone.utc).replace(tzinfo=None)
                 record_step(
                     summary,
                     "adVNTR Genotyping",
@@ -620,23 +621,23 @@ def run_pipeline(
                     advntr_end,
                     write_summary_path=summary_file_path,
                 )
-                logging.info("adVNTR genotyping completed.")
+                logger.info("adVNTR genotyping completed.")
 
                 # --- Cross-Match Variant Comparison ---
-                logging.info("Starting cross-match of Kestrel and adVNTR variant calls.")
-                cross_start = datetime.utcnow()
+                logger.info("Starting cross-match of Kestrel and adVNTR variant calls.")
+                cross_start = datetime.now(timezone.utc).replace(tzinfo=None)
                 # Extract parsed results from the summary
                 kestrel_records, advntr_records = extract_results_from_pipeline_summary(summary)
                 if not kestrel_records:
-                    logging.error("Kestrel genotyping results not found for cross-match.")
+                    logger.error("Kestrel genotyping results not found for cross-match.")
                     raise ValueError("Kestrel genotyping results not found for cross-match.")
                 if not advntr_records:
-                    logging.error("adVNTR genotyping results not found for cross-match.")
+                    logger.error("adVNTR genotyping results not found for cross-match.")
                     raise ValueError("adVNTR genotyping results not found for cross-match.")
                 crossmatch_summary = cross_match_variants(kestrel_records, advntr_records, config=config)
                 cross_match_output = os.path.join(dirs["advntr"], "cross_match_results.tsv")
                 write_results_tsv(crossmatch_summary["matches"], cross_match_output)
-                cross_end = datetime.utcnow()
+                cross_end = datetime.now(timezone.utc).replace(tzinfo=None)
                 record_step(
                     summary,
                     "Cross-Match Variant Comparison",
@@ -647,17 +648,17 @@ def run_pipeline(
                     cross_end,
                     write_summary_path=summary_file_path,
                 )
-                logging.info(
+                logger.info(
                     f"Cross-match variant comparison completed. Overall match: {crossmatch_summary['overall_match']}"
                 )
             else:
-                logging.error("Sorted BAM required for adVNTR not provided.")
+                logger.error("Sorted BAM required for adVNTR not provided.")
                 raise ValueError("Sorted BAM required for adVNTR not provided.")
         else:
-            logging.info("adVNTR module not included. Skipping adVNTR genotyping.")
+            logger.info("adVNTR module not included. Skipping adVNTR genotyping.")
 
         # --- Generate Summary Report and Archiving ---
-        logging.info("Generating summary report.")
+        logger.info("Generating summary report.")
         report_file = "summary_report.html"
         template_dir = config.get("paths", {}).get("template_dir", "vntyper/templates")
 
@@ -680,16 +681,16 @@ def run_pipeline(
             vcf_file=vcf_file,  # Can be .gz, .vcf, or None - handled gracefully
             config=config,
         )
-        logging.info(f"Summary report generated: {report_file}")
+        logger.info(f"Summary report generated: {report_file}")
 
         if archive_results:
-            logging.info("Archiving the results folder.")
+            logger.info("Archiving the results folder.")
             if archive_format == "zip":
                 fmt = "zip"
             elif archive_format == "tar.gz":
                 fmt = "gztar"
             else:
-                logging.error(f"Unsupported archive format: {archive_format}")
+                logger.error(f"Unsupported archive format: {archive_format}")
                 raise ValueError(f"Unsupported archive format: {archive_format}")
 
             archive_name = f"{output_dir}"
@@ -700,11 +701,11 @@ def run_pipeline(
                     root_dir=output_dir,
                     base_dir=".",
                 )
-                logging.info(f"Results folder archived at: {archive_path}")
+                logger.info(f"Results folder archived at: {archive_path}")
             except Exception as exc:
-                logging.error(f"Failed to archive results folder: {exc}")
+                logger.error(f"Failed to archive results folder: {exc}")
 
-        logging.info("Pipeline finished successfully.")
+        logger.info("Pipeline finished successfully.")
 
         # Mark pipeline end in summary
         end_summary(summary)
@@ -712,23 +713,23 @@ def run_pipeline(
         # Write out the complete pipeline summary
         summary_file_path = os.path.join(output_dir, "pipeline_summary.json")
         write_summary(summary, summary_file_path)
-        logging.info(f"Pipeline summary written to: {summary_file_path}")
+        logger.info(f"Pipeline summary written to: {summary_file_path}")
 
         # Generate additional summary output formats if specified
         if summary_formats:
             if "csv" in summary_formats:
                 csv_path = os.path.join(output_dir, "pipeline_summary.csv")
                 convert_summary_to_csv(summary, csv_path)
-                logging.info(f"Pipeline summary CSV written to: {csv_path}")
+                logger.info(f"Pipeline summary CSV written to: {csv_path}")
             if "tsv" in summary_formats:
                 tsv_path = os.path.join(output_dir, "pipeline_summary.tsv")
                 convert_summary_to_tsv(summary, tsv_path)
-                logging.info(f"Pipeline summary TSV written to: {tsv_path}")
+                logger.info(f"Pipeline summary TSV written to: {tsv_path}")
 
-    except Exception as exc:
-        logging.error(f"An error occurred: {exc}", exc_info=True)
+    except Exception:
+        logger.exception("An error occurred")
         sys.exit(1)
 
     overall_stop = timeit.default_timer()
     elapsed_time = (overall_stop - overall_start) / 60
-    logging.info(f"Pipeline completed in {elapsed_time:.2f} minutes.")
+    logger.info(f"Pipeline completed in {elapsed_time:.2f} minutes.")

--- a/vntyper/scripts/reference_registry.py
+++ b/vntyper/scripts/reference_registry.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 reference_registry.py
 
@@ -19,8 +18,12 @@ This design separates coordinate systems from reference sources,
 eliminating duplication and improving maintainability.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import Optional, TypedDict, cast
+from typing import TypedDict, cast
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # Type Definitions
@@ -427,7 +430,7 @@ def get_all_reference_sources() -> list:
 
 
 def resolve_chromosome_name(
-    assembly_name: str, chromosome_number: int = 1, detected_convention: Optional[str] = None
+    assembly_name: str, chromosome_number: int = 1, detected_convention: str | None = None
 ) -> str:
     """
     Resolve chromosome name based on assembly and optional detected convention.
@@ -533,6 +536,6 @@ def validate_registry() -> tuple[bool, list]:
 if __name__ != "__main__":
     is_valid, errors = validate_registry()
     if not is_valid:
-        logging.warning(f"Reference registry validation failed with {len(errors)} errors:")
+        logger.warning(f"Reference registry validation failed with {len(errors)} errors:")
         for error in errors:
-            logging.warning(f"  - {error}")
+            logger.warning(f"  - {error}")

--- a/vntyper/scripts/region_utils.py
+++ b/vntyper/scripts/region_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 region_utils.py
 
@@ -17,6 +16,8 @@ Functions:
 """
 
 import logging
+
+logger = logging.getLogger(__name__)
 
 # Module-level cache for BAM chromosome resolution
 # Key: (bam_file, reference_assembly, chromosome_number), Value: chromosome_name
@@ -59,7 +60,7 @@ def get_region_string(bam_file: str, reference_assembly: str, region_type: str, 
 
     # Resolve assembly alias to coordinate set
     coord_assembly = resolve_assembly_alias(reference_assembly)
-    logging.debug(f"Resolved assembly '{reference_assembly}' to coord set '{coord_assembly}'")
+    logger.debug(f"Resolved assembly '{reference_assembly}' to coord set '{coord_assembly}'")
 
     # Get coordinates from config
     assemblies = config.get("bam_processing", {}).get("assemblies", {})
@@ -86,7 +87,7 @@ def get_region_string(bam_file: str, reference_assembly: str, region_type: str, 
     cache_key = (bam_file, reference_assembly, chromosome_number)
     if cache_key in _chromosome_cache:
         chromosome_name = _chromosome_cache[cache_key]
-        logging.debug(f"Using cached chromosome name: {chromosome_name} for {bam_file}")
+        logger.debug(f"Using cached chromosome name: {chromosome_name} for {bam_file}")
     else:
         # Get actual chromosome name from BAM
         chromosome_name = get_chromosome_name_from_bam(
@@ -94,11 +95,11 @@ def get_region_string(bam_file: str, reference_assembly: str, region_type: str, 
         )
         # Cache the result
         _chromosome_cache[cache_key] = chromosome_name
-        logging.debug(f"Cached chromosome name: {chromosome_name} for {bam_file}")
+        logger.debug(f"Cached chromosome name: {chromosome_name} for {bam_file}")
 
     # Build final region string
     region = build_region_string(chromosome_name, coordinates)
-    logging.debug(f"Built region string: {region} for {region_type} in assembly {reference_assembly}")
+    logger.debug(f"Built region string: {region} for {region_type} in assembly {reference_assembly}")
 
     return region
 
@@ -170,7 +171,7 @@ def resolve_assembly_alias(reference_assembly: str) -> str:
     try:
         return get_coordinate_system(reference_assembly)
     except ValueError as e:
-        logging.warning(f"Unknown assembly '{reference_assembly}', defaulting to 'GRCh37': {e}")
+        logger.warning(f"Unknown assembly '{reference_assembly}', defaulting to 'GRCh37': {e}")
         return "GRCh37"
 
 
@@ -204,7 +205,7 @@ def get_region_string_with_fallback(bam_file: str, reference_assembly: str, regi
         )
 
     except (KeyError, ValueError) as e:
-        logging.warning(f"Dynamic region resolution failed: {e}. Falling back to legacy config lookup.")
+        logger.warning(f"Dynamic region resolution failed: {e}. Falling back to legacy config lookup.")
 
         # Fall back to old method: look up hardcoded region in config
         region_key = f"{region_type.replace('_coords', '')}_{reference_assembly}"
@@ -217,7 +218,7 @@ def get_region_string_with_fallback(bam_file: str, reference_assembly: str, regi
                 f"Neither new nor legacy format available."
             ) from e
 
-        logging.info(f"Using legacy region format: {region_key} = {region}")
+        logger.info(f"Using legacy region format: {region_key} = {region}")
         return region
 
 
@@ -231,10 +232,9 @@ def clear_chromosome_cache():
 
     Should be called between processing different BAM files.
     """
-    global _chromosome_cache
     cache_size = len(_chromosome_cache)
     _chromosome_cache.clear()
-    logging.debug(f"Cleared chromosome cache ({cache_size} entries)")
+    logger.debug(f"Cleared chromosome cache ({cache_size} entries)")
 
 
 def get_cache_info() -> dict:

--- a/vntyper/scripts/scoring.py
+++ b/vntyper/scripts/scoring.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 scoring.py
 
@@ -30,6 +29,8 @@ import logging
 import numpy as np
 import pandas as pd
 
+logger = logging.getLogger(__name__)
+
 
 def split_depth_and_calculate_frame_score(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -51,11 +52,11 @@ def split_depth_and_calculate_frame_score(df: pd.DataFrame) -> pd.DataFrame:
             Adds 'Frame_Score' and a boolean column 'is_frameshift'.
             Does NOT filter out rows.
     """
-    logging.debug("Entering split_depth_and_calculate_frame_score")
-    logging.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Entering split_depth_and_calculate_frame_score")
+    logger.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
 
     if df.empty:
-        logging.debug("DataFrame is empty. Exiting split_depth_and_calculate_frame_score.")
+        logger.debug("DataFrame is empty. Exiting split_depth_and_calculate_frame_score.")
         return df
 
     # Step 1) Split 'Sample' into 3 parts
@@ -75,8 +76,8 @@ def split_depth_and_calculate_frame_score(df: pd.DataFrame) -> pd.DataFrame:
     # Step 3) Mark frameshift in a new boolean column
     df["is_frameshift"] = (df["alt_len"] - df["ref_len"]) % 3 != 0
 
-    logging.debug("Exiting split_depth_and_calculate_frame_score")
-    logging.debug(f"Final row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Exiting split_depth_and_calculate_frame_score")
+    logger.debug(f"Final row count: {len(df)}, columns: {df.columns.tolist()}")
     return df
 
 
@@ -99,11 +100,11 @@ def split_frame_score(df: pd.DataFrame) -> pd.DataFrame:
             Adds 'direction' and 'frameshift_amount'.
             Retains all rows and intermediate columns for debugging.
     """
-    logging.debug("Entering split_frame_score")
-    logging.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Entering split_frame_score")
+    logger.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
 
     if df.empty:
-        logging.debug("DataFrame is empty. Exiting split_frame_score.")
+        logger.debug("DataFrame is empty. Exiting split_frame_score.")
         return df
 
     # Step 1) Determine direction
@@ -112,8 +113,8 @@ def split_frame_score(df: pd.DataFrame) -> pd.DataFrame:
     # Step 2) Calculate frameshift_amount
     df["frameshift_amount"] = (df["alt_len"] - df["ref_len"]).abs() % 3
 
-    logging.debug("Exiting split_frame_score")
-    logging.debug(f"Final row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Exiting split_frame_score")
+    logger.debug(f"Final row count: {len(df)}, columns: {df.columns.tolist()}")
     return df
 
 
@@ -138,11 +139,11 @@ def extract_frameshifts(df: pd.DataFrame) -> pd.DataFrame:
             Adds 'is_valid_frameshift' (bool).
             Keeps all rows.
     """
-    logging.debug("Entering extract_frameshifts")
-    logging.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Entering extract_frameshifts")
+    logger.debug(f"Initial row count: {len(df)}, columns: {df.columns.tolist()}")
 
     if df.empty:
-        logging.debug("DataFrame is empty. Exiting extract_frameshifts.")
+        logger.debug("DataFrame is empty. Exiting extract_frameshifts.")
         return df
 
     # Identify insertion vs deletion frameshifts
@@ -151,6 +152,6 @@ def extract_frameshifts(df: pd.DataFrame) -> pd.DataFrame:
 
     df["is_valid_frameshift"] = condition_insertion | condition_deletion
 
-    logging.debug("Exiting extract_frameshifts")
-    logging.debug(f"Final row count: {len(df)}, columns: {df.columns.tolist()}")
+    logger.debug("Exiting extract_frameshifts")
+    logger.debug(f"Final row count: {len(df)}, columns: {df.columns.tolist()}")
     return df

--- a/vntyper/scripts/summary.py
+++ b/vntyper/scripts/summary.py
@@ -16,7 +16,7 @@ so that all available data is expanded into individual columns.
 import csv
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def start_summary(version=None, input_files=None):
@@ -31,7 +31,7 @@ def start_summary(version=None, input_files=None):
         dict: A summary dictionary with pipeline start timestamp, version, input files, and an empty steps list.
     """
     return {
-        "pipeline_start": datetime.utcnow().isoformat(),
+        "pipeline_start": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
         "version": version if version is not None else "unknown",
         "input_files": input_files if input_files is not None else {},
         "steps": [],
@@ -45,7 +45,7 @@ def end_summary(summary):
     Args:
         summary (dict): The summary dictionary to update.
     """
-    summary["pipeline_end"] = datetime.utcnow().isoformat()
+    summary["pipeline_end"] = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
 
 def md5sum(file_path):
@@ -96,7 +96,7 @@ def parse_tsv(file_path):
                     header = line.split("\t")
                     continue
                 row_values = line.split("\t")
-                row_dict = {key: value for key, value in zip(header, row_values)}
+                row_dict = dict(zip(header, row_values))
                 data.append(row_dict)
     except Exception as e:
         comments.append(f"Error parsing TSV file: {e}")
@@ -132,7 +132,7 @@ def parse_csv(file_path):
                 if header is None:
                     header = row
                     continue
-                row_dict = {key: value for key, value in zip(header, row)}
+                row_dict = dict(zip(header, row))
                 data.append(row_dict)
     except Exception as e:
         comments.append(f"Error parsing CSV file: {e}")
@@ -283,7 +283,7 @@ def convert_summary_to_csv(summary, output_csv_path):
     for record in flattened_steps:
         all_keys.update(record.keys())
     # Use a sorted list of keys for consistent column order
-    all_keys = sorted(list(all_keys))
+    all_keys = sorted(all_keys)
 
     with open(output_csv_path, "w", newline="", encoding="utf-8") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=all_keys)
@@ -308,7 +308,7 @@ def convert_summary_to_tsv(summary, output_tsv_path):
     all_keys = set()
     for record in flattened_steps:
         all_keys.update(record.keys())
-    all_keys = sorted(list(all_keys))
+    all_keys = sorted(all_keys)
 
     with open(output_tsv_path, "w", newline="", encoding="utf-8") as tsvfile:
         writer = csv.DictWriter(tsvfile, fieldnames=all_keys, delimiter="\t")
@@ -327,9 +327,9 @@ if __name__ == "__main__":
     result_file = "example_results.tsv"  # Path to your result file
     file_type = "tsv"  # Could be "tsv", "csv", or "json"
     command = "run_example --option value"
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc).replace(tzinfo=None)
     # Simulate some processing delay
-    end_time = datetime.utcnow()
+    end_time = datetime.now(timezone.utc).replace(tzinfo=None)
 
     # Record the step (this will calculate the MD5 and parse the file)
     record_step(

--- a/vntyper/scripts/utils.py
+++ b/vntyper/scripts/utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # vntyper/scripts/utils.py
 
 import gzip
@@ -9,6 +8,8 @@ import os
 import shlex
 import subprocess
 import sys
+
+logger = logging.getLogger(__name__)
 
 
 def run_command(command, log_file, critical=False, cwd=None):
@@ -27,9 +28,9 @@ def run_command(command, log_file, critical=False, cwd=None):
     Returns:
         bool: True if the command succeeded, False otherwise.
     """
-    logging.debug(f"Running command: {command}")
+    logger.debug(f"Running command: {command}")
     if cwd is not None:
-        logging.debug(f"Working directory: {cwd}")
+        logger.debug(f"Working directory: {cwd}")
 
     with open(log_file, "w") as lf:
         process = subprocess.Popen(
@@ -43,11 +44,11 @@ def run_command(command, log_file, critical=False, cwd=None):
         for line in process.stdout:
             decoded_line = line.decode()
             lf.write(decoded_line)
-            logging.debug(decoded_line.strip())
+            logger.debug(decoded_line.strip())
         process.wait()
 
         if process.returncode != 0:
-            logging.debug(f"Command failed: {command}")
+            logger.debug(f"Command failed: {command}")
             if critical:
                 raise RuntimeError(f"Critical command failed: {command}")
             return False
@@ -62,12 +63,12 @@ def setup_logging(log_level=logging.INFO, log_file=None):
         log_level (int): Logging level (e.g., logging.INFO).
         log_file (str, optional): Path to a log file. If None, logs are printed to console.
     """
-    logger = logging.getLogger()  # Get the root logger
-    logger.setLevel(log_level)  # Set the overall logging level
+    root_logger = logging.getLogger()  # Get the root logger
+    root_logger.setLevel(log_level)  # Set the overall logging level
 
     # Clear existing handlers so we don't duplicate logs
-    if logger.hasHandlers():
-        logger.handlers.clear()
+    if root_logger.hasHandlers():
+        root_logger.handlers.clear()
 
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
@@ -76,13 +77,13 @@ def setup_logging(log_level=logging.INFO, log_file=None):
         file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(log_level)
         file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
+        root_logger.addHandler(file_handler)
 
     # Always attach a console handler at the same requested log level
     console_handler = logging.StreamHandler()
     console_handler.setLevel(log_level)
     console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+    root_logger.addHandler(console_handler)
 
 
 def create_output_directories(base_output_dir):
@@ -108,11 +109,11 @@ def create_output_directories(base_output_dir):
         try:
             if not os.path.exists(dir_path):
                 os.makedirs(dir_path)
-                logging.info(f"Created directory: {dir_path}")
+                logger.info(f"Created directory: {dir_path}")
             else:
-                logging.info(f"Directory already exists: {dir_path}")
+                logger.info(f"Directory already exists: {dir_path}")
         except Exception as e:
-            logging.error(f"Failed to create directory {dir_path}: {e}")
+            logger.error(f"Failed to create directory {dir_path}: {e}")
             raise
 
     return dirs
@@ -133,7 +134,7 @@ def get_tool_version(command, version_flag):
     try:
         # Split the command properly in case it's a compound command like "mamba run ..."
         full_command = shlex.split(command) + shlex.split(version_flag)
-        result = subprocess.run(full_command, capture_output=True, text=True)
+        result = subprocess.run(full_command, capture_output=True, text=True, check=False)
         output = result.stdout.strip() or result.stderr.strip()
 
         # Parse version from the output based on the command
@@ -166,16 +167,16 @@ def get_tool_version(command, version_flag):
         return "unknown"
 
     except FileNotFoundError:
-        logging.error(f"Command not found: {command}")
+        logger.error(f"Command not found: {command}")
         return "unknown"
     except PermissionError:
-        logging.error(f"Permission denied: {command}")
+        logger.error(f"Permission denied: {command}")
         return "unknown"
     except IndexError as e:
-        logging.error(f"Failed to parse version for {command}: {e}")
+        logger.error(f"Failed to parse version for {command}: {e}")
         return "unknown"
     except Exception as e:
-        logging.error(f"Failed to get version for {command}: {e}")
+        logger.error(f"Failed to get version for {command}: {e}")
         return "unknown"
 
 
@@ -227,16 +228,16 @@ def search(regex: str, df, case=False):
     Returns:
         DataFrame: A DataFrame containing the rows where the pattern was found.
     """
-    logging.debug("Starting regex search in DataFrame.")
+    logger.debug("Starting regex search in DataFrame.")
     try:
         textlikes = df.select_dtypes(include=[object, "object"])
         result_df = df[
             textlikes.apply(lambda column: column.str.contains(regex, regex=True, case=case, na=False)).any(axis=1)
         ]
-        logging.debug("Regex search completed.")
+        logger.debug("Regex search completed.")
         return result_df
     except Exception as e:
-        logging.error(f"Error during regex search: {e}")
+        logger.error(f"Error during regex search: {e}")
         raise
 
 
@@ -255,24 +256,24 @@ def load_config(config_path=None):
         try:
             with open(config_path) as config_file:
                 config = json.load(config_file)
-                logging.info(f"Configuration loaded from {config_path}")
+                logger.info(f"Configuration loaded from {config_path}")
                 return config
         except json.JSONDecodeError as e:
-            logging.error(f"Error decoding JSON from the config file: {e}")
+            logger.error(f"Error decoding JSON from the config file: {e}")
             raise
         except Exception as e:
-            logging.error(f"Unexpected error loading config file {config_path}: {e}")
+            logger.error(f"Unexpected error loading config file {config_path}: {e}")
             raise
     else:
         # No config path provided or file does not exist; use default config from package data
         try:
             with pkg_resources.open_text("vntyper", "config.json") as f:
                 config = json.load(f)
-                logging.info("Loaded default config from package data.")
+                logger.info("Loaded default config from package data.")
                 return config
         except Exception as e:
-            logging.error("Error: Default config file not found in package data.")
-            logging.error(e)
+            logger.error("Error: Default config file not found in package data.")
+            logger.error(e)
             sys.exit(1)
 
 
@@ -294,16 +295,16 @@ def validate_bam_file(file_path, cwd=None):
         ValueError: If any validation check fails.
     """
     if not file_path:
-        logging.error("No alignment file provided.")
+        logger.error("No alignment file provided.")
         raise ValueError("No alignment file provided.")
 
     if not os.path.isfile(file_path):
-        logging.error(f"Alignment file does not exist: {file_path}")
+        logger.error(f"Alignment file does not exist: {file_path}")
         raise ValueError(f"Alignment file does not exist: {file_path}")
 
     # Modified to allow both .bam and .cram extensions
-    if not (file_path.endswith(".bam") or file_path.endswith(".cram")):
-        logging.error(f"Invalid alignment file extension for file: {file_path}. Must be .bam or .cram")
+    if not (file_path.endswith((".bam", ".cram"))):
+        logger.error(f"Invalid alignment file extension for file: {file_path}. Must be .bam or .cram")
         raise ValueError(f"Invalid alignment file extension for file: {file_path}")
 
     # Perform samtools quickcheck
@@ -311,10 +312,10 @@ def validate_bam_file(file_path, cwd=None):
     log_file = f"{file_path}.quickcheck.log"
     success = run_command(command, log_file, critical=True, cwd=cwd)
     if not success:
-        logging.error(f"Alignment file failed quickcheck: {file_path}")
+        logger.error(f"Alignment file failed quickcheck: {file_path}")
         raise ValueError(f"Alignment file failed quickcheck: {file_path}")
 
-    logging.info(f"Alignment file validated successfully: {file_path}")
+    logger.info(f"Alignment file validated successfully: {file_path}")
 
 
 def validate_fastq_file(file_path):
@@ -328,16 +329,16 @@ def validate_fastq_file(file_path):
         ValueError: If any validation check fails.
     """
     if not file_path:
-        logging.error("No FASTQ file provided.")
+        logger.error("No FASTQ file provided.")
         raise ValueError("No FASTQ file provided.")
 
     if not os.path.isfile(file_path):
-        logging.error(f"FASTQ file does not exist: {file_path}")
+        logger.error(f"FASTQ file does not exist: {file_path}")
         raise ValueError(f"FASTQ file does not exist: {file_path}")
 
     valid_extensions = (".fastq", ".fastq.gz", ".fq", ".fq.gz")
     if not file_path.endswith(valid_extensions):
-        logging.error(f"Invalid FASTQ file extension for file: {file_path}")
+        logger.error(f"Invalid FASTQ file extension for file: {file_path}")
         raise ValueError(f"Invalid FASTQ file extension for file: {file_path}")
 
     # Check basic FASTQ formatting by reading the first few lines
@@ -347,9 +348,9 @@ def validate_fastq_file(file_path):
             for _ in range(4):  # Read first 4 lines of the first read
                 line = f.readline()
                 if not line:
-                    logging.error(f"FASTQ file is incomplete or empty: {file_path}")
+                    logger.error(f"FASTQ file is incomplete or empty: {file_path}")
                     raise ValueError(f"FASTQ file is incomplete or empty: {file_path}")
-        logging.info(f"FASTQ file validated successfully: {file_path}")
+        logger.info(f"FASTQ file validated successfully: {file_path}")
     except Exception as e:
-        logging.error(f"Error validating FASTQ file {file_path}: {e}")
+        logger.error(f"Error validating FASTQ file {file_path}: {e}")
         raise

--- a/vntyper/scripts/variant_parsing.py
+++ b/vntyper/scripts/variant_parsing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 variant_parsing.py
 
@@ -25,11 +24,14 @@ References:
 - Saei et al., iScience 26, 107171 (2023)
 """
 
+from __future__ import annotations
+
 import gzip
 import logging
-from typing import Optional
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 def read_vcf_without_comments(vcf_file: str) -> pd.DataFrame:
@@ -47,7 +49,7 @@ def read_vcf_without_comments(vcf_file: str) -> pd.DataFrame:
     """
     open_func = gzip.open if vcf_file.endswith(".gz") else open
     data = []
-    header: Optional[list] = None
+    header: list | None = None
 
     try:
         with open_func(vcf_file, "rt") as f:
@@ -57,16 +59,16 @@ def read_vcf_without_comments(vcf_file: str) -> pd.DataFrame:
                 elif not line.startswith("##") and header:
                     data.append(line.strip().split("\t"))
     except FileNotFoundError:
-        logging.error(f"VCF file not found: {vcf_file}")
+        logger.error(f"VCF file not found: {vcf_file}")
         return pd.DataFrame()
     except Exception as e:
-        logging.error(f"Error reading VCF file {vcf_file}: {e}")
+        logger.error(f"Error reading VCF file {vcf_file}: {e}")
         return pd.DataFrame()
 
     if data and header:
-        logging.debug(f"VCF read successfully with {len(data)} records.")
+        logger.debug(f"VCF read successfully with {len(data)} records.")
         return pd.DataFrame(data, columns=header)
-    logging.debug("No variant records found in VCF.")
+    logger.debug("No variant records found in VCF.")
     return pd.DataFrame()
 
 
@@ -94,17 +96,17 @@ def filter_by_alt_values_and_finalize(df: pd.DataFrame, kestrel_config: dict) ->
             Intermediate columns like 'left', 'right' are no longer dropped;
             they remain for debugging.
     """
-    logging.debug("Entering filter_by_alt_values_and_finalize")
-    logging.debug(f"Initial DataFrame shape: {df.shape}")
+    logger.debug("Entering filter_by_alt_values_and_finalize")
+    logger.debug(f"Initial DataFrame shape: {df.shape}")
 
     if df.empty:
-        logging.debug("DataFrame is empty. Exiting filter_by_alt_values_and_finalize.")
+        logger.debug("DataFrame is empty. Exiting filter_by_alt_values_and_finalize.")
         return df
 
     required_columns = {"ALT", "Depth_Score"}
     missing_columns = required_columns - set(df.columns)
     if missing_columns:
-        logging.error(f"Missing required columns: {missing_columns}")
+        logger.error(f"Missing required columns: {missing_columns}")
         raise KeyError(f"Missing required columns: {missing_columns}")
 
     alt_filter = kestrel_config.get("alt_filtering", {})
@@ -123,6 +125,6 @@ def filter_by_alt_values_and_finalize(df: pd.DataFrame, kestrel_config: dict) ->
     # Instead of filtering the DataFrame, we store a new boolean column
     df["alt_filter_pass"] = (~is_gg | meets_gg_threshold) & not_excluded_alt
 
-    logging.debug("Exiting filter_by_alt_values_and_finalize")
-    logging.debug(f"Final DataFrame shape: {df.shape}")
+    logger.debug("Exiting filter_by_alt_values_and_finalize")
+    logger.debug(f"Final DataFrame shape: {df.shape}")
     return df

--- a/vntyper/version.py
+++ b/vntyper/version.py
@@ -1,3 +1,3 @@
 # vntyper/version.py
 
-__version__ = "2.0.3"
+__version__ = "2.0.4"


### PR DESCRIPTION
Consolidates #169. Two related pieces of work: set the repo up for agentic development,
and repair the CI that was already red on `main`.

---

## 1. `.gitignore` was hiding new documentation pages

`docs/` was ignored (a leftover from the Sphinx block of the Python gitignore template)
even though the 39 MkDocs sources under `docs/` are tracked. Tracked files were fine,
but **any newly created page was invisible to `git add` and `git status`**:

```
$ git check-ignore -v docs/new.md
.gitignore:73:docs/	docs/new.md
```

Since `docs.yml` runs `mkdocs build --strict`, adding a page, registering it in
`mkdocs.yml` `nav:`, and forgetting `git add -f` gives a green local build and a red CI
run. Only `docs/_build/` is kept now.

Same pass: `Dockerfile` → `/Dockerfile` so the local-dev rule cannot shadow
`docker/Dockerfile`; track shared agent config and ignore only per-developer overrides;
ignore the local `adVNTR/` clone that showed up as untracked noise in every `git status`.

## 2. AGENTS.md

Follows the [agents.md](https://agents.md) convention — one file at the repo root, read
by Claude Code, Codex, Cursor, Gemini CLI and others. Derived from a review of the build
tooling, test setup, package architecture and contribution history rather than restating
the README. Covers setup, canonical `make` targets, layout, code style, testing rules,
git/PR conventions, and the traps that are genuinely easy to get wrong:

- config JSON loaded into module globals at **import** time, so `--config-path` cannot
  override it and tests must patch the module global
- flagging and cross-match rules are `eval()`d strings referencing DataFrame column
  names — renaming a column turns flags off with only a warning
- Kestrel stages **mark, they don't filter** (`is_frameshift`, `alt_filter_pass`, …)
- conda env names `envadvntr` / `shark_env` are load-bearing in `config.json`
- tool and reference paths are CWD-relative; the `project_root` plumbing must stay
- Kestrel pinned to 1.0.1 (scoring is calibrated to it)
- pushing a `v*.*.*` tag publishes to PyPI immediately

`CLAUDE.md` is a 5-line pointer so guidance lives in one place. `.claude/settings.json`
pre-approves read-only verification commands and denies `git tag` / `twine upload`.

---

## 3. CI repair

**`main` was already red before this branch** — and not from a code regression.
`pyproject.toml` used `extend-select`, which **builds on ruff's default rule set**, and
`[dev]` pins `ruff>=0.8.0` with no upper bound. Ruff 0.16 widened its defaults, so ~440
rules the project never opted into switched on at once:

| ruff | result on identical code |
| --- | --- |
| 0.14.3 | `All checks passed!` |
| 0.16.1 | `Found 740 errors.` |

Separately `mypy>=1.0.0` resolved to 2.x, which rejects the Makefile's hardcoded
`--python-version 3.9` (*"must be 3.10 or higher"*) — the type-check job failed before
analyzing anything.

The choice was to fix the code rather than pin the toolchain.

### Logging (613 of the 740)

Every module now declares `logger = logging.getLogger(__name__)` and calls
`logger.<level>(...)`. `setup_logging()` still configures the root logger and module
loggers propagate to it, so handlers, levels and log files are unchanged — but records
now carry the real module name, which the existing `%(name)s` format string already
printed (previously always `root`):

```
2026-08-05 18:15:19,173 - vntyper.scripts.scoring - INFO - propagation-probe
```

Also removed the import-time `logging.basicConfig()` in `advntr_genotyping.py`.

### Remaining 127, all behaviour-preserving

- `DTZ003`/`DTZ005` — `datetime.utcnow()` is deprecated in 3.12. Replaced with
  `datetime.now(timezone.utc).replace(tzinfo=None)` so the naive-UTC ISO strings in
  `pipeline_summary.json` stay **byte-identical** (`cohort_summary.py` parses them back
  with `fromisoformat`), and `datetime.now(timezone.utc).astimezone()` for report dates
  so local-time rendering is unchanged.
- `EXE001` — removed shebangs from importable library modules (none were executable).
- `FA100` + `UP007`/`UP045` — `from __future__ import annotations`, then PEP 604 unions.
- `PLW1510` — explicit `check=False`; every caller already inspects `returncode`.
- `PLW0602` — dropped two `global` statements that never assign.
- `G201`/`TRY401`, `B009`, `C4`, `PIE`, `PERF`, `FURB`, `TRY201`, `RUF100` — mechanical.

### Config made explicit

`select` instead of `extend-select`, so ruff's defaults can no longer change what CI
enforces. Two omissions are now documented decisions rather than accidents:

- **`BLE001`** (46 blind `except Exception`) — not selected. Catch-all at stage and
  process boundaries is this pipeline's intended error contract (log, then `exit 1`);
  narrowing all 46 needs per-call knowledge of what each external tool raises.
- **`G004`** (f-strings in log calls) — not selected; it is the established style across
  all ~600 log statements.
- `PERF203` ignored: per-iteration error handling is deliberate so one bad sample cannot
  abort a whole cohort.

mypy config moved into `[tool.mypy]`. The runtime floor stays 3.9 (`requires-python` and
the CI matrix are untouched); 3.10 is only mypy's analysis target, and ruff's
`target-version = "py39"` still guards against 3.10+ syntax.

**Bonus fix** — `pytest --log-cli=false` exits 4 with `unrecognized arguments` (`log_cli`
is an ini option, not a flag), so `make test-quiet` has never worked. Now
`-o log_cli=false`.

---

## Verification

Run in the project's own `vntyper` conda env (**Python 3.9.19**, the real minimum), and
again under a newer toolchain to prove the result no longer depends on tool version:

```
ruff 0.14.3 (py3.9 env)      make lint          → All checks passed!
                             make format-check  → All checks passed!
ruff 0.16.1 (py3.12)         ruff check vntyper/ → All checks passed!

mypy 1.19.1 (py3.9 env)      mypy vntyper/ tests/ → Success: no issues found in 57 source files
mypy 2.3.0  (py3.12)         mypy vntyper/        → Success: no issues found in 30 source files

pytest 9.0.2 (py3.9 env)     pytest --co -q     → 332 tests collected
                             pytest -m unit -q  → 278 passed, 54 deselected
```

Log propagation was verified directly: a record emitted through a module logger still
reaches the file handler installed by `setup_logging()`.

Not run locally: integration and Docker suites (they need the 1.1 GB Zenodo archive, a
Docker daemon and reference genomes). CI runs the Docker quick suite on PRs to `main`.

## Still not fixed

`tests/unit/test_haplo_count_and_selection.py` declares no `pytestmark`, so its 30 tests
never run in CI — visible as part of the "54 deselected" above. Left alone deliberately:
enabling them may surface real failures that deserve their own PR, not a drive-by fix
inside a lint change. Documented in AGENTS.md so agents add the marker to new test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW3Z5Gx2MBSzGzp38QMFKa