### PR TITLE
perf(ci): cut the Docker pipeline from 53 min to ~3 min, fix the build's correctness, and move the image to Python 3.12

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -88,8 +88,16 @@ tests/benchmark/
 
 # Bioinformatics Data Files (CRITICAL - Saves 143GB+)
 # =============================================================================
-# Large reference genome files
-reference/
+# Large reference genome files.
+# Exclude the GENERATED bulk only, not the whole directory. The small tracked files at
+# reference/ top level (~192 KB total) are real image inputs: muc1_region_hg19.fa is
+# required by the SHARK module via shark_config.json, and vntr_db_advntr.zip carries the
+# adVNTR databases that config.json points at. The old Dockerfile obtained them by
+# `git clone`ing the repo; now they come from the build context, so they must not be
+# ignored. Everything multi-GB lives in the two subdirectories below.
+reference/alignment/
+reference/vntr_db_advntr/
+reference/*.log
 reference_old/
 
 # User output and downloads
@@ -173,3 +181,21 @@ dmypy.json
 *.db
 *.sqlite
 *.sqlite3
+
+# Local clone of the upstream adVNTR source tree. It is in .gitignore, but Docker does
+# NOT read .gitignore - without this line it was 46 MB of a 49 MB build context, and
+# install_advntr.sh would collide with a context-copied tree.
+adVNTR/
+
+# Dev tooling caches and agent config - never needed in an image
+.ruff_cache/
+.benchmarks/
+.claude/
+AGENTS.md
+CLAUDE.md
+
+# Docs and workflow sources are not part of the runtime image
+docs/
+snakemake/
+mkdocs.yml
+.github/

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,6 +63,14 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
+      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
+      # (`error: The interpreter at /usr is externally managed`). Create an explicit
+      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
+      - name: Create virtualenv
+        run: |
+          uv venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
       # Ruff is a standalone binary. This job used to `pip install -e .[dev]`, pulling
       # the full scientific stack (pandas, numpy, matplotlib, plotly, pysam, ...) - 28s
       # of installing to run a 0s lint.
@@ -72,7 +80,7 @@ jobs:
       # ruff. Going through `make` keeps CI and local scope identical - formatting was
       # previously checked only locally and not gated at all in CI.
       - name: Install ruff
-        run: uv pip install --system ruff
+        run: uv pip install ruff
 
       - run: make lint
       - run: make format-check
@@ -93,8 +101,16 @@ jobs:
           python-version: '3.10'
           enable-cache: true
 
+      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
+      # (`error: The interpreter at /usr is externally managed`). Create an explicit
+      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
+      - name: Create virtualenv
+        run: |
+          uv venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
       # mypy genuinely needs the runtime deps installed to resolve imports.
-      - run: uv pip install --system -e .[dev]
+      - run: uv pip install -e .[dev]
 
       - run: make type-check
 
@@ -120,7 +136,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
-      - run: uv pip install --system -e .[dev]
+      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
+      # (`error: The interpreter at /usr is externally managed`). Create an explicit
+      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
+      - name: Create virtualenv
+        run: |
+          uv venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - run: uv pip install -e .[dev]
 
       # Enforces the coverage floor as well as the tests. tests/unit/test_marker_hygiene.py
       # additionally fails the build if any unit test file is missing its `unit` marker.
@@ -143,7 +167,15 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
-      - run: uv pip install --system -e .[docs]
+      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
+      # (`error: The interpreter at /usr is externally managed`). Create an explicit
+      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
+      - name: Create virtualenv
+        run: |
+          uv venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - run: uv pip install -e .[docs]
 
       # docs.yml only builds on push to main, so a PR that breaks `mkdocs --strict`
       # was previously only discovered after merge, when the deploy failed.

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -63,14 +63,20 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
-      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
-      # (`error: The interpreter at /usr is externally managed`). Create an explicit
-      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
-      - name: Create virtualenv
+      # Do NOT use `uv pip install --system`: ubuntu-24.04's interpreter is PEP 668
+      # "externally managed" and uv refuses it outright. setup-uv already creates and
+      # activates a venv when given `python-version`, so normally this only has to put
+      # it on PATH for later `make`/`pytest` steps. The fallback covers the case where
+      # setup-uv did not create one.
+      - name: Ensure the uv environment is on PATH
         run: |
-          uv venv
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [ -z "${VIRTUAL_ENV:-}" ]; then
+            uv venv
+            VIRTUAL_ENV="$PWD/.venv"
+            echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          fi
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       # Ruff is a standalone binary. This job used to `pip install -e .[dev]`, pulling
       # the full scientific stack (pandas, numpy, matplotlib, plotly, pysam, ...) - 28s
       # of installing to run a 0s lint.
@@ -101,14 +107,20 @@ jobs:
           python-version: '3.10'
           enable-cache: true
 
-      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
-      # (`error: The interpreter at /usr is externally managed`). Create an explicit
-      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
-      - name: Create virtualenv
+      # Do NOT use `uv pip install --system`: ubuntu-24.04's interpreter is PEP 668
+      # "externally managed" and uv refuses it outright. setup-uv already creates and
+      # activates a venv when given `python-version`, so normally this only has to put
+      # it on PATH for later `make`/`pytest` steps. The fallback covers the case where
+      # setup-uv did not create one.
+      - name: Ensure the uv environment is on PATH
         run: |
-          uv venv
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [ -z "${VIRTUAL_ENV:-}" ]; then
+            uv venv
+            VIRTUAL_ENV="$PWD/.venv"
+            echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          fi
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       # mypy genuinely needs the runtime deps installed to resolve imports.
       - run: uv pip install -e .[dev]
 
@@ -136,14 +148,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
-      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
-      # (`error: The interpreter at /usr is externally managed`). Create an explicit
-      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
-      - name: Create virtualenv
+      # Do NOT use `uv pip install --system`: ubuntu-24.04's interpreter is PEP 668
+      # "externally managed" and uv refuses it outright. setup-uv already creates and
+      # activates a venv when given `python-version`, so normally this only has to put
+      # it on PATH for later `make`/`pytest` steps. The fallback covers the case where
+      # setup-uv did not create one.
+      - name: Ensure the uv environment is on PATH
         run: |
-          uv venv
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [ -z "${VIRTUAL_ENV:-}" ]; then
+            uv venv
+            VIRTUAL_ENV="$PWD/.venv"
+            echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          fi
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       - run: uv pip install -e .[dev]
 
       # Enforces the coverage floor as well as the tests. tests/unit/test_marker_hygiene.py
@@ -167,14 +185,20 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
-      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
-      # (`error: The interpreter at /usr is externally managed`). Create an explicit
-      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
-      - name: Create virtualenv
+      # Do NOT use `uv pip install --system`: ubuntu-24.04's interpreter is PEP 668
+      # "externally managed" and uv refuses it outright. setup-uv already creates and
+      # activates a venv when given `python-version`, so normally this only has to put
+      # it on PATH for later `make`/`pytest` steps. The fallback covers the case where
+      # setup-uv did not create one.
+      - name: Ensure the uv environment is on PATH
         run: |
-          uv venv
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [ -z "${VIRTUAL_ENV:-}" ]; then
+            uv venv
+            VIRTUAL_ENV="$PWD/.venv"
+            echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          fi
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       - run: uv pip install -e .[docs]
 
       # docs.yml only builds on push to main, so a PR that breaks `mkdocs --strict`

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,9 +29,9 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -63,9 +63,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9
         with:
           python-version: '3.12'
           enable-cache: true
@@ -107,9 +107,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9
         with:
           python-version: '3.10'
           enable-cache: true
@@ -148,9 +148,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -185,9 +185,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9
         with:
           python-version: '3.12'
           enable-cache: true

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: '3.12'
           enable-cache: true
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: '3.10'
           enable-cache: true
@@ -150,7 +150,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -187,7 +187,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: '3.12'
           enable-cache: true

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,112 +1,172 @@
 name: CI Tests
 
-# Run on push to main/develop and on all pull requests
+# NOTE: no workflow-level `paths:` filter. A workflow skipped by a path filter leaves
+# its required status check permanently "Pending" and blocks the merge, whereas a job
+# skipped by an `if:` reports "Success". So filtering happens per job below, gated on
+# the `changes` job, and `ci-success` is the single required check.
 on:
   push:
-    branches: [main, develop, docker-modernization-2025]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
-# Ensure only one workflow runs at a time for each PR
+# Cancel superseded PR runs, but never abandon a run on main.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
 
 jobs:
-  # Job 1: Code Quality (Linting)
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'vntyper/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'pytest.ini'
+              - 'Makefile'
+              - '.github/workflows/ci-tests.yml'
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+              - '.github/workflows/ci-tests.yml'
+
   lint:
     name: Lint (Ruff)
-    runs-on: ubuntu-latest
-
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.10'
-          cache: 'pip'
+          python-version: '3.12'
+          enable-cache: true
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+      # Ruff is a standalone binary. This job used to `pip install -e .[dev]`, pulling
+      # the full scientific stack (pandas, numpy, matplotlib, plotly, pysam, ...) - 28s
+      # of installing to run a 0s lint.
+      #
+      # Unpinned on purpose: [tool.ruff.lint] uses an explicit `select`, so results are
+      # reproducible across ruff versions and CI cannot drift from a developer's local
+      # ruff. Going through `make` keeps CI and local scope identical - formatting was
+      # previously checked only locally and not gated at all in CI.
+      - name: Install ruff
+        run: uv pip install --system ruff
 
-      - name: Run linting (make lint)
-        run: make lint
+      - run: make lint
+      - run: make format-check
 
-  # Job 2: Type Checking
   typecheck:
     name: Type Check (mypy)
-    runs-on: ubuntu-latest
-
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.10'
-          cache: 'pip'
+          enable-cache: true
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+      # mypy genuinely needs the runtime deps installed to resolve imports.
+      - run: uv pip install --system -e .[dev]
 
-      - name: Run type checking (make type-check)
-        run: make type-check
+      - run: make type-check
 
-  # Job 3: Unit Tests (fast, multiple Python versions)
   test-unit:
     name: Unit Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    # Pinned, not ubuntu-latest: Python 3.9 is EOL (2025-10-31) and has no build for
+    # ubuntu-26.04, so this job breaks silently when the `latest` label moves.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          enable-cache: true
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+      - run: uv pip install --system -e .[dev]
 
-      - name: Run unit tests (make test-unit)
-        run: make test-unit
+      # Enforces the coverage floor as well as the tests. tests/unit/test_marker_hygiene.py
+      # additionally fails the build if any unit test file is missing its `unit` marker.
+      - name: Run unit tests with coverage floor
+        run: make test-unit-cov
 
-      - name: Display test summary
-        if: always()
-        run: |
-          echo "✓ Unit tests completed for Python ${{ matrix.python-version }}"
+  docs:
+    name: Docs build (strict)
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
 
-  # Job 4: Summary (all checks must pass)
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - run: uv pip install --system -e .[docs]
+
+      # docs.yml only builds on push to main, so a PR that breaks `mkdocs --strict`
+      # was previously only discovered after merge, when the deploy failed.
+      - run: mkdocs build --strict
+
   ci-success:
     name: CI Success
-    needs: [lint, typecheck, test-unit]
-    runs-on: ubuntu-latest
+    # THE required status check. Keep this the only one, so job-level `if:` filtering
+    # never leaves a required check pending.
+    needs: [changes, lint, typecheck, test-unit, docs]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     if: always()
-
     steps:
-      - name: Check all jobs succeeded
+      - name: Check all jobs succeeded or were legitimately skipped
+        env:
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          if [[ "${{ needs.lint.result }}" != "success" ]] || \
-             [[ "${{ needs.typecheck.result }}" != "success" ]] || \
-             [[ "${{ needs.test-unit.result }}" != "success" ]]; then
-            echo "❌ One or more CI jobs failed"
+          echo "$RESULTS"
+          # A skipped job is acceptable (path filter said it was irrelevant).
+          # A failed or cancelled job is not.
+          if echo "$RESULTS" | grep -qE '"result": *"(failure|cancelled)"'; then
+            echo "❌ One or more CI jobs failed or were cancelled"
             exit 1
-          else
-            echo "✅ All CI checks passed!"
           fi
+          echo "✅ All CI checks passed"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -41,6 +41,13 @@ jobs:
               - 'pyproject.toml'
               - 'pytest.ini'
               - 'Makefile'
+              # scripts/ holds the coverage gate and the test-data fetcher; a change
+              # to the gate itself must run the tests it gates, or a regression in it
+              # merges green with test-unit skipped.
+              - 'scripts/**'
+              # The image's interpreter and dependency pins are asserted against
+              # pyproject by tests/unit/test_version_consistency.py.
+              - 'conda/**'
               - '.github/workflows/ci-tests.yml'
             docs:
               - 'docs/**'
@@ -130,8 +137,8 @@ jobs:
     name: Unit Tests (Python ${{ matrix.python-version }})
     needs: changes
     if: needs.changes.outputs.python == 'true'
-    # Pinned, not ubuntu-latest: Python 3.9 is EOL (2025-10-31) and has no build for
-    # ubuntu-26.04, so this job breaks silently when the `latest` label moves.
+    # Pinned rather than ubuntu-latest so a runner-image rollover cannot change the
+    # toolchain underneath a green build without a commit.
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -139,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -55,7 +55,7 @@ jobs:
     outputs:
       tag: ${{ steps.hash.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Content-addressed tag. The app workflow recomputes this from the same files at
       # the same commit, so a change to conda/** that has not had its base built yet
@@ -78,7 +78,7 @@ jobs:
         id: img
         run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')-base" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -97,12 +97,12 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
         if: steps.exists.outputs.skip != 'true'
 
       - name: Build and push base image
         if: steps.exists.outputs.skip != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.base

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -29,6 +29,14 @@ on:
         description: 'Rebuild even if this content hash already exists'
         type: boolean
         default: false
+  # Callable from docker-build.yml so a PR that changes a base input (or the very
+  # first run, before any base exists) builds the base it needs instead of failing.
+  # Without this, every PR touching conda/** would be permanently red.
+  workflow_call:
+    outputs:
+      tag:
+        description: 'Content-addressed tag of the base image'
+        value: ${{ jobs.build-base.outputs.tag }}
 
 concurrency:
   group: docker-base-${{ github.ref }}
@@ -55,7 +63,7 @@ jobs:
       - name: Compute base image tag
         id: hash
         env:
-          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**') }}
+          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**', 'reference/**', '.dockerignore') }}
         run: |
           set -euo pipefail
           # hashFiles() returns "" when nothing matched, which would silently produce the

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -107,9 +107,15 @@ jobs:
           context: .
           file: docker/Dockerfile.base
           push: true
+          # `:latest` ONLY from a push to main. This workflow is also called from
+          # docker-build.yml on pull requests, and tagging latest there would let an
+          # unmerged - possibly failing - PR overwrite the base that `make docker-build`
+          # and every other consumer pull by default, or clobber a verified main base if
+          # it finished later. The content-addressed tag is always safe to publish: it
+          # is immutable by construction.
           tags: |
             ${{ steps.img.outputs.name }}:${{ steps.hash.outputs.tag }}
-            ${{ steps.img.outputs.name }}:latest
+            ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && format('{0}:latest', steps.img.outputs.name) || '' }}
           # type=registry on ghcr, not type=gha: the GitHub Actions cache is capped at
           # 10 GB per repo with hourly LRU eviction and is still marked beta, while GHCR
           # storage is free and uncapped for public repos. A mode=max cache for this

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -16,6 +16,12 @@ on:
       - 'vntyper/scripts/install_references.py'
       - 'vntyper/scripts/install_references_config.json'
       - 'vntyper/dependencies/advntr/**'
+      # The tracked reference files are COPYed into the base, and .dockerignore
+      # decides which of them reach the build context at all. Omitting these two was
+      # how a .dockerignore rule silently dropped three config-declared reference
+      # files from the image without triggering a base rebuild.
+      - 'reference/**'
+      - '.dockerignore'
       - '.github/workflows/docker-base.yml'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,0 +1,111 @@
+name: Docker Base Image
+
+# Builds the expensive foundation: three conda environments, compiled adVNTR, the
+# FastAPI/Celery stack, and the reference genomes with their BWA indexes.
+#
+# This only runs when one of those inputs actually changes - historically a handful of
+# times a year. The per-commit application image (docker-build.yml) layers onto it and
+# builds in ~3 minutes instead of 40-70.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'conda/**'
+      - 'docker/Dockerfile.base'
+      - 'docker/requirements-web.txt'
+      - 'vntyper/scripts/install_references.py'
+      - 'vntyper/scripts/install_references_config.json'
+      - 'vntyper/dependencies/advntr/**'
+      - '.github/workflows/docker-base.yml'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Rebuild even if this content hash already exists'
+        type: boolean
+        default: false
+
+concurrency:
+  group: docker-base-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  build-base:
+    name: Build base image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      tag: ${{ steps.hash.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Content-addressed tag. The app workflow recomputes this from the same files at
+      # the same commit, so a change to conda/** that has not had its base built yet
+      # fails loudly with a missing tag instead of silently using a stale base.
+      - name: Compute base image tag
+        id: hash
+        env:
+          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**') }}
+        run: |
+          set -euo pipefail
+          # hashFiles() returns "" when nothing matched, which would silently produce the
+          # constant tag "base-" for every build. Fail instead.
+          if [ -z "$HASH" ]; then
+            echo "::error::hashFiles() matched no files - check the path patterns"
+            exit 1
+          fi
+          echo "tag=base-${HASH:0:16}" >> "$GITHUB_OUTPUT"
+
+      - name: Normalize image name
+        id: img
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')-base" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # A rebuild of identical content is ~25 minutes of nothing. Skip it unless forced.
+      - name: Check whether this content was already built
+        id: exists
+        run: |
+          set -euo pipefail
+          REF="${{ steps.img.outputs.name }}:${{ steps.hash.outputs.tag }}"
+          if [ "${{ inputs.force }}" != "true" ] && docker manifest inspect "$REF" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$REF already exists - skipping rebuild"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-buildx-action@v3
+        if: steps.exists.outputs.skip != 'true'
+
+      - name: Build and push base image
+        if: steps.exists.outputs.skip != 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.base
+          push: true
+          tags: |
+            ${{ steps.img.outputs.name }}:${{ steps.hash.outputs.tag }}
+            ${{ steps.img.outputs.name }}:latest
+          # type=registry on ghcr, not type=gha: the GitHub Actions cache is capped at
+          # 10 GB per repo with hourly LRU eviction and is still marked beta, while GHCR
+          # storage is free and uncapped for public repos. A mode=max cache for this
+          # image alone exceeded the entire Actions cache budget.
+          cache-from: type=registry,ref=${{ steps.img.outputs.name }}:buildcache
+          cache-to: type=registry,ref=${{ steps.img.outputs.name }}:buildcache,mode=max
+
+      - name: Summary
+        run: |
+          echo "### Base image" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tag: \`${{ steps.img.outputs.name }}:${{ steps.hash.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Rebuilt: \`${{ steps.exists.outputs.skip != 'true' }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,6 +46,10 @@ jobs:
               - 'conda/**'
               - 'tests/**'
               - 'pyproject.toml'
+              # .dockerignore decides what reaches the build context, so a change to
+              # it can alter the image without touching any other path here.
+              - '.dockerignore'
+              - 'reference/**'
               - '.github/workflows/docker-build.yml'
 
   # Build and test in ONE job. The image never leaves the runner's daemon, so there is
@@ -137,11 +141,6 @@ jobs:
           # export the cache from branches in this repository.
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache-{1},mode=max', steps.img.outputs.app, github.ref_name) || '' }}
 
-      - name: Smoke test the image
-        run: |
-          set -euo pipefail
-          docker run --rm --entrypoint /opt/conda/envs/vntyper/bin/vntyper vntyper:test --version
-
       - name: Set up Python for the test suite
         uses: astral-sh/setup-uv@v5
         with:
@@ -149,6 +148,46 @@ jobs:
           enable-cache: true
 
       - run: uv pip install --system -e .[dev]
+
+      # Structural checks against the built image: ~1s, one container start, no network
+      # inside it and no Zenodo data. Deliberately BEFORE the test-data restore, so a
+      # structurally broken image fails in seconds instead of after a 1.1 GB download.
+      #
+      # The load-bearing assertion is that every reference path config.json declares
+      # actually exists in the image - derived from the config inside the container, not
+      # from a hardcoded list that would drift from it.
+      - name: Image structure smoke tests
+        env:
+          VNTYPER_TEST_IMAGE: vntyper:test
+        run: pytest -m smoke tests/docker -o log_cli=false -q --junitxml=smoke-results.xml
+
+      - name: Summarise smoke results
+        if: always()
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import pathlib
+          import xml.etree.ElementTree as ET
+
+          path = pathlib.Path("smoke-results.xml")
+          if not path.exists():
+              print("## Image smoke tests\n\nNo results produced.")
+              raise SystemExit
+          root = ET.parse(path).getroot()
+          suite = root.find("testsuite")
+          if suite is None:
+              suite = root
+          print("## Image smoke tests\n")
+          print(
+              f"**{suite.get('tests')} assertions** in {float(suite.get('time', 0)):.2f}s "
+              f"- {suite.get('failures')} failed, {suite.get('errors')} errored\n"
+          )
+          for case in suite.iter("testcase"):
+              node = case.find("failure")
+              if node is None:
+                  node = case.find("error")
+              if node is not None:
+                  print(f"- `{case.get('name')}`\n\n  ```\n  {(node.get('message') or '')[:500]}\n  ```")
+          PY
 
       - name: Restore test data cache
         id: cache-test-data

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,10 +14,23 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # Previously absent entirely, so two pushes landing inside the ~30 min build window
-  # each ran a full cold build. Never cancel main; always cancel superseded PR runs.
+  # A group was previously absent entirely, so two pushes inside the ~30 min build
+  # window each ran a full cold build.
+  #
+  # cancel-in-progress is deliberately FALSE, including for pull requests. When the
+  # base image is missing, this run builds it - roughly 25 minutes - and a push landing
+  # meanwhile would throw that away, so a burst of pushes could starve the base build
+  # indefinitely. Cancelling cannot be made conditional on "is a base being built":
+  # `concurrency` is evaluated when the run starts, before any job, and its expressions
+  # may only use the github, inputs and vars contexts - not `needs` or job outputs.
+  #
+  # The cost of not cancelling is small now: the per-commit application build is ~3 min
+  # (it was ~30 before the base/app split), and a superseded run's base build is
+  # idempotent - docker-base.yml skips immediately when the content hash is already
+  # published. Cancellation was worth it when every build was half an hour; it is not
+  # worth discarding a 25-minute base build to save 3 minutes of runner time.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 permissions: {}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -208,7 +208,15 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
-      - run: uv pip install --system -e .[dev]
+      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
+      # (`error: The interpreter at /usr is externally managed`). Create an explicit
+      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
+      - name: Create virtualenv
+        run: |
+          uv venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+      - run: uv pip install -e .[dev]
 
       # Structural checks against the built image: ~1s, one container start, no network
       # inside it and no Zenodo data. Deliberately BEFORE the test-data restore, so a

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -208,14 +208,20 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
-      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
-      # (`error: The interpreter at /usr is externally managed`). Create an explicit
-      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
-      - name: Create virtualenv
+      # Do NOT use `uv pip install --system`: ubuntu-24.04's interpreter is PEP 668
+      # "externally managed" and uv refuses it outright. setup-uv already creates and
+      # activates a venv when given `python-version`, so normally this only has to put
+      # it on PATH for later `make`/`pytest` steps. The fallback covers the case where
+      # setup-uv did not create one.
+      - name: Ensure the uv environment is on PATH
         run: |
-          uv venv
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [ -z "${VIRTUAL_ENV:-}" ]; then
+            uv venv
+            VIRTUAL_ENV="$PWD/.venv"
+            echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          fi
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       - run: uv pip install -e .[dev]
 
       # Structural checks against the built image: ~1s, one container start, no network

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,8 +35,8 @@ jobs:
     outputs:
       image: ${{ steps.filter.outputs.image }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -65,9 +65,9 @@ jobs:
     outputs:
       missing: ${{ steps.check.outputs.missing }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
@@ -135,7 +135,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Normalize image names
         id: img
@@ -157,9 +157,9 @@ jobs:
           fi
           echo "tag=base-${HASH:0:16}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
@@ -179,7 +179,7 @@ jobs:
           fi
           echo "ref=${{ steps.img.outputs.base }}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ${{ steps.img.outputs.app }}
@@ -193,7 +193,7 @@ jobs:
       # directly. Nothing is pushed here - publishing happens after the tests pass.
       - name: Build application image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
@@ -210,7 +210,7 @@ jobs:
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache-{1},mode=max', steps.img.outputs.app, github.ref_name) || '' }}
 
       - name: Set up Python for the test suite
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v9
         with:
           python-version: '3.12'
           enable-cache: true
@@ -273,7 +273,7 @@ jobs:
 
       - name: Restore test data cache
         id: cache-test-data
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: tests/data
           key: test-data-v3-${{ hashFiles('tests/test_data_config.json', 'scripts/download_test_data.py') }}
@@ -307,7 +307,7 @@ jobs:
         if: >-
           github.event_name == 'push' &&
           (steps.cache-test-data.outputs.cache-hit != 'true' || steps.verify.outputs.needs_download == 'true')
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: tests/data
           key: test-data-v3-${{ hashFiles('tests/test_data_config.json', 'scripts/download_test_data.py') }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,6 +52,59 @@ jobs:
               - 'reference/**'
               - '.github/workflows/docker-build.yml'
 
+  # Does the base image this commit needs already exist? Cheap check, no build.
+  base-status:
+    name: Check base image
+    needs: changes
+    if: needs.changes.outputs.image == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      missing: ${{ steps.check.outputs.missing }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for the content-addressed base tag
+        id: check
+        env:
+          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**', 'reference/**', '.dockerignore') }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HASH" ]; then
+            echo "::error::hashFiles() matched no files - check the path patterns"
+            exit 1
+          fi
+          LOWER=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+          REF="${{ env.GHCR_REGISTRY }}/${LOWER}-base:base-${HASH:0:16}"
+          if docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+            echo "missing=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Base $REF is published."
+          else
+            echo "missing=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Base $REF is not published; it will be built first."
+          fi
+
+  # Build the base only when this commit's inputs have no published base. Steady state
+  # this is skipped in seconds; it fires on the first run and whenever a PR changes
+  # conda/**, the reference config, or .dockerignore.
+  build-base:
+    name: Build base image
+    needs: [changes, base-status]
+    if: needs.base-status.outputs.missing == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-base.yml
+
   # Build and test in ONE job. The image never leaves the runner's daemon, so there is
   # no push-then-pull round trip and no multi-GB artifact upload, and the two stages are
   # no longer serialized behind a `needs:` edge that existed only to sequence them.
@@ -60,8 +113,15 @@ jobs:
   # pushed first and tested afterwards.
   build-and-test:
     name: Build and test image
-    needs: changes
-    if: needs.changes.outputs.image == 'true'
+    # `always()` so this still runs when build-base was skipped (base already
+    # published); a plain `needs` would skip this job too.
+    needs: [changes, base-status, build-base]
+    if: >-
+      always() &&
+      needs.changes.outputs.image == 'true' &&
+      needs.base-status.result == 'success' &&
+      needs.build-base.result != 'failure' &&
+      needs.build-base.result != 'cancelled'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
@@ -81,7 +141,7 @@ jobs:
       - name: Compute expected base image tag
         id: hash
         env:
-          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**') }}
+          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**', 'reference/**', '.dockerignore') }}
         run: |
           set -euo pipefail
           if [ -z "$HASH" ]; then
@@ -98,15 +158,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Resolve the base tag to an immutable digest, and fail with an actionable message
-      # rather than a confusing pull error if it was never built.
+      # Pin to an immutable digest rather than the tag, so the image cannot change under
+      # us if the tag is ever re-pushed. By this point the `build-base` job has published
+      # the base if it was missing, so a failure here is a genuine fault, not bootstrap.
       - name: Resolve base image digest
         id: base
         run: |
           set -euo pipefail
           REF="${{ steps.img.outputs.base }}:${{ steps.hash.outputs.tag }}"
           if ! DIGEST=$(docker buildx imagetools inspect "$REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
-            echo "::error::Base image $REF does not exist. A dependency input changed - run the 'Docker Base Image' workflow (workflow_dispatch) or merge the change to main first."
+            echo "::error::Base image $REF is missing even though the build-base job did not fail. Check that job's logs, or re-run 'Docker Base Image' with force=true."
             exit 1
           fi
           echo "ref=${{ steps.img.outputs.base }}@${DIGEST}" >> "$GITHUB_OUTPUT"
@@ -264,7 +325,7 @@ jobs:
 
   docker-success:
     name: Docker Success
-    needs: [changes, build-and-test]
+    needs: [changes, base-status, build-base, build-and-test]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,10 +88,17 @@ jobs:
           if docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
             echo "missing=false" >> "$GITHUB_OUTPUT"
             echo "::notice::Base $REF is published."
-          else
-            echo "missing=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Base $REF is not published; it will be built first."
+            exit 0
           fi
+          # A fork PR's GITHUB_TOKEN is read-only, so it cannot publish a base. Say so
+          # plainly instead of letting the push fail with an authorization error.
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "::error::This fork PR changes a base image input, but $REF is not published and a fork cannot push to ghcr.io. A maintainer needs to run the 'Docker Base Image' workflow (workflow_dispatch) against this commit's inputs, or merge the base change first."
+            exit 1
+          fi
+          echo "missing=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Base $REF is not published; it will be built first."
 
   # Build the base only when this commit's inputs have no published base. Steady state
   # this is skipped in seconds; it fires on the first run and whenever a PR changes

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,107 +1,157 @@
-# This workflow is run as part of CI to test that they run through.
-#
-# The images are pushed to `ghcr.io` and 'docker hub' for each PR and branch.  The ones for
-# the releases are pushed in `release-please.yml`.
 name: Docker Build
 
+# Builds the per-commit application image on top of the base image produced by
+# docker-base.yml, then runs the Docker test tiers against THAT image.
+#
+# No workflow-level `paths:` filter - a skipped workflow leaves a required check
+# pending forever. Filtering is per job, gated on `changes`, with `docker-success` as
+# the single required check.
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
-  workflow_dispatch:  # Allow manual trigger
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # Previously absent entirely, so two pushes landing inside the ~30 min build window
+  # each ran a full cold build. Never cancel main; always cancel superseded PR runs.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
 
 env:
   GHCR_REGISTRY: ghcr.io
-  DOCKERHUB_REGISTRY: docker.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: read
-      packages: write  # Required for ghcr.io
-
+      pull-requests: read
+    outputs:
+      image: ${{ steps.filter.outputs.image }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            image:
+              - 'vntyper/**'
+              - 'docker/**'
+              - 'conda/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - '.github/workflows/docker-build.yml'
 
-      # Set up Docker Buildx (required for caching)
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  # Build and test in ONE job. The image never leaves the runner's daemon, so there is
+  # no push-then-pull round trip and no multi-GB artifact upload, and the two stages are
+  # no longer serialized behind a `needs:` edge that existed only to sequence them.
+  #
+  # It also means images are published only after their tests pass; the old workflow
+  # pushed first and tested afterwards.
+  build-and-test:
+    name: Build and test image
+    needs: changes
+    if: needs.changes.outputs.image == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
 
-      # Log in to GitHub Container Registry (ghcr.io)
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Normalize image names
+        id: img
+        run: |
+          LOWER=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')
+          echo "app=${{ env.GHCR_REGISTRY }}/${LOWER}" >> "$GITHUB_OUTPUT"
+          echo "base=${{ env.GHCR_REGISTRY }}/${LOWER}-base" >> "$GITHUB_OUTPUT"
+
+      # Must match docker-base.yml exactly.
+      - name: Compute expected base image tag
+        id: hash
+        env:
+          HASH: ${{ hashFiles('conda/**', 'docker/Dockerfile.base', 'docker/requirements-web.txt', 'vntyper/scripts/install_references.py', 'vntyper/scripts/install_references_config.json', 'vntyper/dependencies/advntr/**') }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HASH" ]; then
+            echo "::error::hashFiles() matched no files - check the path patterns"
+            exit 1
+          fi
+          echo "tag=base-${HASH:0:16}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Log in to Docker Hub
-      #- name: Log in to Docker Hub
-        #uses: docker/login-action@v3
-        #with:
-          #registry: ${{ env.DOCKERHUB_REGISTRY }}
-          #username: ${{ secrets.DOCKER_USERNAME }}  # Added to GitHub secrets
-          #password: ${{ secrets.DOCKER_PASSWORD }}  # Added to GitHub secrets
+      # Resolve the base tag to an immutable digest, and fail with an actionable message
+      # rather than a confusing pull error if it was never built.
+      - name: Resolve base image digest
+        id: base
+        run: |
+          set -euo pipefail
+          REF="${{ steps.img.outputs.base }}:${{ steps.hash.outputs.tag }}"
+          if ! DIGEST=$(docker buildx imagetools inspect "$REF" --format '{{.Manifest.Digest}}' 2>/dev/null); then
+            echo "::error::Base image $REF does not exist. A dependency input changed - run the 'Docker Base Image' workflow (workflow_dispatch) or merge the change to main first."
+            exit 1
+          fi
+          echo "ref=${{ steps.img.outputs.base }}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
-      # Extract metadata (tags, labels) for Docker
-      - name: Extract metadata (tags, labels) for Docker
+      - uses: docker/metadata-action@v5
         id: meta
-        uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ steps.img.outputs.app }}
           tags: |
-            type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
             type=sha
 
-      # Build and push Docker image to both registries
-      - name: Build and push Docker image
+      # load: true exports into the runner's Docker daemon so the tests can use it
+      # directly. Nothing is pushed here - publishing happens after the tests pass.
+      - name: Build application image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.ref }}
+          tags: vntyper:test
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          # Enable GitHub Actions caching for 60-80% faster builds
-          # Using scoped cache to prevent stale reference issues (fixes "failed to compute cache key" errors)
-          # See: https://github.com/docker/buildx/issues/681
-          cache-from: type=gha,scope=build-${{ github.ref_name }}
-          cache-to: type=gha,scope=build-${{ github.ref_name }},mode=max
+          load: true
+          cache-from: |
+            type=registry,ref=${{ steps.img.outputs.app }}:buildcache-${{ github.ref_name }}
+            type=registry,ref=${{ steps.img.outputs.app }}:buildcache-main
+          # Fork PRs get a read-only GITHUB_TOKEN and cannot write to ghcr, so only
+          # export the cache from branches in this repository.
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache-{1},mode=max', steps.img.outputs.app, github.ref_name) || '' }}
 
-  # Docker Quick Tests - Run on all PRs for fast feedback
-  test-docker-quick:
-    name: Docker Tests (Quick)
-    needs: build-and-push-image
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-
-      - name: Install dependencies
+      - name: Smoke test the image
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
+          set -euo pipefail
+          docker run --rm --entrypoint /opt/conda/envs/vntyper/bin/vntyper vntyper:test --version
 
-      # Restore test data cache (uses cache/restore to allow saving even on failure)
+      - name: Set up Python for the test suite
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - run: uv pip install --system -e .[dev]
+
       - name: Restore test data cache
-        id: cache-test-data-restore
+        id: cache-test-data
         uses: actions/cache/restore@v4
         with:
           path: tests/data
@@ -109,143 +159,84 @@ jobs:
           restore-keys: |
             test-data-v3-
 
-      # Verify cache contents if cache was restored
+      # Verify a restored cache, and record whether it has to be refetched. The old
+      # version did `rm -rf tests/data; exit 0` here, but the download step was gated on
+      # `cache-hit != 'true'` - false on this path - so nothing was ever re-downloaded
+      # and the job failed at final verification. A corrupted cache was unrecoverable
+      # until someone hand-bumped the cache key.
       - name: Verify cached test data
-        if: steps.cache-test-data-restore.outputs.cache-hit == 'true'
+        id: verify
+        if: steps.cache-test-data.outputs.cache-hit == 'true'
         run: |
-          echo "Cache was restored. Verifying integrity..."
-          python scripts/download_test_data.py --verify-only || {
-            echo "⚠ Cache verification failed. Will re-download."
+          if ! python scripts/download_test_data.py --verify-only; then
+            echo "⚠ Cache verification failed; will re-download."
             rm -rf tests/data
-            exit 0
-          }
-          echo "✓ Cache is valid"
+            echo "needs_download=true" >> "$GITHUB_OUTPUT"
+          fi
 
-      # Download test data if not cached or verification failed
-      # Uses the same Python script as local development for consistency
       - name: Download test data
-        if: steps.cache-test-data-restore.outputs.cache-hit != 'true'
-        run: |
-          echo "Downloading test data (1.1GB archive from Zenodo)..."
-          echo "Using Python download script (same as local development)"
-          echo "This ensures consistent extraction logic between local and CI"
-          echo ""
+        if: steps.cache-test-data.outputs.cache-hit != 'true' || steps.verify.outputs.needs_download == 'true'
+        run: python scripts/download_test_data.py
+        timeout-minutes: 30
 
-          # Use the standalone download script
-          # This ensures 100% identical behavior between local and CI
-          python scripts/download_test_data.py
-        timeout-minutes: 240
-
-      # Save test data cache IMMEDIATELY after download (before tests run)
-      # This ensures cache persists even if tests fail/timeout later
+      # Only save from main. A cache written on a PR is scoped to refs/pull/N/merge and
+      # can never be read by main or by any other PR - it just consumes the shared 10 GB
+      # quota and evicts caches that ARE reusable.
       - name: Save test data cache
+        if: >-
+          github.event_name == 'push' &&
+          (steps.cache-test-data.outputs.cache-hit != 'true' || steps.verify.outputs.needs_download == 'true')
         uses: actions/cache/save@v4
-        if: steps.cache-test-data-restore.outputs.cache-hit != 'true'
         with:
           path: tests/data
           key: test-data-v3-${{ hashFiles('tests/test_data_config.json', 'scripts/download_test_data.py') }}
 
-      # Final verification before running tests
       - name: Final test data verification
-        run: |
-          echo "Running final verification before tests..."
-          python scripts/download_test_data.py --verify-only
-          echo "✓ Test data is ready"
+        run: python scripts/download_test_data.py --verify-only
 
-      - name: Run Docker quick tests
+      # On PRs run the fast subset; on main run everything. The old workflow ran the
+      # quick tier and then the full tier serially on main, but every quick test carries
+      # @pytest.mark.docker, so the full suite re-ran all of them - ~13 min of the
+      # critical path for zero extra information.
+      - name: Run Docker tests
         env:
-          # Disable automatic downloads in pytest fixtures (fail fast if data missing)
+          VNTYPER_TEST_IMAGE: vntyper:test
           VNTYPER_TEST_DATA_SKIP_DOWNLOAD: "1"
-        run: make test-docker-quick
-        timeout-minutes: 20
-
-      - name: Display test summary
-        if: always()
         run: |
-          echo "✓ Docker quick tests completed"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            make test-docker-quick
+          else
+            make test-docker
+          fi
 
-  # Docker Full Test Suite - Run only on main branch
-  test-docker-full:
-    name: Docker Tests (Full Suite)
-    needs: [build-and-push-image, test-docker-quick]
-    runs-on: ubuntu-latest
-    # Only run full suite on main branch or manual trigger
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+      # Publish only now, once the image has actually passed its tests. The previous
+      # workflow pushed to ghcr before any test ran. PRs never publish: a fork PR's
+      # GITHUB_TOKEN is read-only, and a tag per PR accumulated multi-GB images forever.
+      - name: Push image
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Pushing $tag"
+            docker tag vntyper:test "$tag"
+            docker push "$tag"
+          done
 
+  docker-success:
+    name: Docker Success
+    needs: [changes, build-and-test]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always()
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
-
-      # Restore test data cache (uses cache/restore to allow saving even on failure)
-      - name: Restore test data cache
-        id: cache-test-data-full-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: tests/data
-          key: test-data-v3-${{ hashFiles('tests/test_data_config.json', 'scripts/download_test_data.py') }}
-          restore-keys: |
-            test-data-v3-
-
-      # Verify cache contents if cache was restored
-      - name: Verify cached test data
-        if: steps.cache-test-data-full-restore.outputs.cache-hit == 'true'
-        run: |
-          echo "Cache was restored. Verifying integrity..."
-          python scripts/download_test_data.py --verify-only || {
-            echo "⚠ Cache verification failed. Will re-download."
-            rm -rf tests/data
-            exit 0
-          }
-          echo "✓ Cache is valid"
-
-      # Download test data if not cached or verification failed
-      - name: Download test data
-        if: steps.cache-test-data-full-restore.outputs.cache-hit != 'true'
-        run: |
-          echo "Downloading test data (1.1GB archive from Zenodo)..."
-          echo "Using Python download script (same as local development)"
-          python scripts/download_test_data.py --quiet
-        timeout-minutes: 120
-
-      # Save test data cache IMMEDIATELY after download (before tests run)
-      - name: Save test data cache
-        uses: actions/cache/save@v4
-        if: steps.cache-test-data-full-restore.outputs.cache-hit != 'true'
-        with:
-          path: tests/data
-          key: test-data-v3-${{ hashFiles('tests/test_data_config.json', 'scripts/download_test_data.py') }}
-
-      # Final verification before running tests
-      - name: Final test data verification
-        run: |
-          echo "Running final verification before tests..."
-          python scripts/download_test_data.py --verify-only
-          echo "✓ Test data is ready"
-
-      - name: Run full Docker test suite
+      - name: Check all jobs succeeded or were legitimately skipped
         env:
-          # Disable automatic downloads in pytest fixtures (fail fast if data missing)
-          VNTYPER_TEST_DATA_SKIP_DOWNLOAD: "1"
-        run: make test-docker
-        timeout-minutes: 240
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-test-results-${{ github.run_id }}
-          path: |
-            pytest-results/
-            htmlcov/
-          retention-days: 30
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          echo "$RESULTS"
+          if echo "$RESULTS" | grep -qE '"result": *"(failure|cancelled)"'; then
+            echo "❌ One or more Docker jobs failed or were cancelled"
+            exit 1
+          fi
+          echo "✅ Docker pipeline passed"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -210,7 +210,7 @@ jobs:
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache-{1},mode=max', steps.img.outputs.app, github.ref_name) || '' }}
 
       - name: Set up Python for the test suite
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: '3.12'
           enable-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,8 +36,16 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
+      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
+      # (`error: The interpreter at /usr is externally managed`). Create an explicit
+      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
+      - name: Create virtualenv
+        run: |
+          uv venv
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
-        run: uv pip install --system ".[docs]"
+        run: uv pip install ".[docs]"
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,14 +36,20 @@ jobs:
           python-version: '3.12'
           enable-cache: true
 
-      # uv refuses `--system` on Ubuntu's PEP 668 "externally managed" interpreter
-      # (`error: The interpreter at /usr is externally managed`). Create an explicit
-      # venv and put it on PATH so later `make`/`pytest` steps resolve tools from it.
-      - name: Create virtualenv
+      # Do NOT use `uv pip install --system`: ubuntu-24.04's interpreter is PEP 668
+      # "externally managed" and uv refuses it outright. setup-uv already creates and
+      # activates a venv when given `python-version`, so normally this only has to put
+      # it on PATH for later `make`/`pytest` steps. The fallback covers the case where
+      # setup-uv did not create one.
+      - name: Ensure the uv environment is on PATH
         run: |
-          uv venv
-          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [ -z "${VIRTUAL_ENV:-}" ]; then
+            uv venv
+            VIRTUAL_ENV="$PWD/.venv"
+            echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
+          fi
+          echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: uv pip install ".[docs]"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v9
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: '3.12'
           enable-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,7 @@
 name: Deploy Documentation
 
+# Deploy only. PR-time validation of `mkdocs build --strict` lives in the `docs` job of
+# ci-tests.yml, so a broken docs change is caught before merge rather than here.
 on:
   push:
     branches: [main]
@@ -9,10 +11,8 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Least privilege at workflow level; the write scopes are granted per job below.
+permissions: {}
 
 concurrency:
   group: pages
@@ -20,17 +20,24 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # Building the site needs no write access at all. `pages: write` and
+    # `id-token: write` were previously granted here too, via the workflow-level block.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.12'
-          cache: pip
+          enable-cache: true
 
       - name: Install dependencies
-        run: pip install ".[docs]"
+        run: uv pip install --system ".[docs]"
 
       - name: Build documentation
         run: mkdocs build --strict
@@ -42,7 +49,11 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,11 +27,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9
         with:
           python-version: '3.12'
           enable-cache: true
@@ -57,7 +57,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site/
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -60,7 +60,11 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME#v}"
-          PKG=$(python -c "import re,pathlib; print(re.search(r'\"([^\"]+)\"', pathlib.Path('vntyper/version.py').read_text()).group(1))")
+          # Execute version.py and read __version__, rather than regexing the first
+          # quoted string: that would silently pick the wrong value if the literal ever
+          # changes quoting, becomes an expression, or gains a neighbouring string.
+          # runpy avoids importing the whole vntyper package (and its dependencies).
+          PKG=$(python -c "import runpy; print(runpy.run_path('vntyper/version.py')['__version__'])")
           echo "tag=$TAG  package=$PKG"
           if [ "$TAG" != "$PKG" ]; then
             echo "::error::Tag v$TAG does not match vntyper/version.py ($PKG). Fix the version and re-tag."

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,13 +1,24 @@
 # Publish to PyPI when a version tag (v*.*.*) is pushed.
-# Requires PyPI API token stored as GitHub secret: PYPI_API_TOKEN
-#
-# Setup: GitHub repo → Settings → Secrets and variables → Actions → New repository secret
-#        Name: PYPI_API_TOKEN   Value: your PyPI API token (pypi.org → Account → API tokens)
 #
 # Usage:
-#   git tag v2.0.1
-#   git push origin v2.0.1
+#   git tag -a v2.0.5 -m "Release 2.0.5"
+#   git push origin v2.0.5
 #
+# Currently authenticates with the PYPI_API_TOKEN repository secret.
+#
+# RECOMMENDED FOLLOW-UP - migrate to Trusted Publishing (OIDC):
+#   PyPI now recommends Trusted Publishing over long-lived API tokens: the credential is
+#   short-lived, scoped to this project, and cannot leak from the secret store. It also
+#   turns on PEP 740 attestations by default.
+#
+#   This is a two-part change and MUST be done in this order, or the next release fails:
+#     1. On pypi.org: Manage project -> Publishing -> add a GitHub publisher with
+#        owner=hassansaei, repo=VNtyper, workflow=publish-pypi.yml, environment=pypi
+#     2. In this file: add `id-token: write` to the publish job's permissions, replace
+#        the twine step with `uses: pypa/gh-action-pypi-publish@release/v1` (no
+#        `password:`), and delete the PYPI_API_TOKEN secret.
+#   Deliberately not done unilaterally here, because step 2 without step 1 breaks
+#   publishing.
 name: Publish to PyPI
 
 on:
@@ -15,22 +26,46 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions: {}
+
 jobs:
   build-and-publish:
     name: Build and publish to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # NOTE: no `environment:` here yet. It is required for Trusted Publishing and is
+    # added as part of that migration (see the header), together with the matching
+    # environment name in the PyPI publisher config. Adding it now would only introduce
+    # a new failure mode on the release path without any benefit.
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install build tools
         run: python -m pip install --upgrade pip build twine
+
+      # Publishing is irreversible: a version can never be re-uploaded to PyPI. Catch a
+      # tag/version mismatch here rather than after burning the version number.
+      - name: Verify tag matches vntyper.version.__version__
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python -c "import re,pathlib; print(re.search(r'\"([^\"]+)\"', pathlib.Path('vntyper/version.py').read_text()).group(1))")
+          echo "tag=$TAG  package=$PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match vntyper/version.py ($PKG). Fix the version and re-tag."
+            exit 1
+          fi
 
       - name: Build package
         run: python -m build
@@ -42,4 +77,5 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        # --skip-existing so a re-run after a partial failure is not a hard error.
+        run: twine upload --skip-existing dist/*

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -42,12 +42,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ fastp.json
 plan/
 forbidden_strings.txt
 reference/forbidden_strings.txt
+.ci-local-venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Neither exists — use the commands above.
 | Task | Command |
 | --- | --- |
 | Full pre-PR gate | `make check-all` |
+| Everything CI runs, locally | `make ci-local` |
+| Everything the image CI runs | `make ci-local-docker` |
 | Format + autofix | `make format` |
 | Lint | `make lint` |
 | Type check | `make type-check` |
@@ -46,7 +48,19 @@ Neither exists — use the commands above.
 
 Always run `make check-all` before opening a PR. It gates on the **unit** tier only
 (~0.5 s) so it is runnable on a fresh clone; use `make check-full` when you also want the
-tiers that need the 1.1 GB Zenodo archive. Run pytest **from the repo root** —
+tiers that need the 1.1 GB Zenodo archive.
+
+**If you changed anything under `.github/workflows/`, `make check-all` is not enough —
+run `make ci-local`.** It mirrors `ci-tests.yml` job for job (actionlint, format, lint,
+mypy, unit tests + coverage, strict docs build) *and* rebuilds the environment from
+scratch through CI's own installer via `make ci-local-uv`. That last part matters:
+`ci-local`'s other steps run in whatever environment you already have, so they cannot
+catch breakage in how CI *builds* its environment — which is exactly how
+`uv pip install --system` shipped green locally and then failed every CI job (see trap
+14). `make ci-local-docker` covers the image workflow. Neither target skips silently:
+if a required tool is missing they fail and say so.
+
+Run pytest **from the repo root** —
 `tests/parametrization.py` opens `tests/test_data_config.json` by relative path at
 collection time, so any other CWD breaks collection, including `-m unit`.
 
@@ -238,7 +252,15 @@ Known offenders, worst first: `docker/app/main.py` (1081), `install_references.p
 12. **Version lives in three places**: `vntyper/version.py` (authoritative),
     `CITATION.cff`, and `docs/about/changelog.md`. `publish-pypi.yml` refuses to publish
     if the pushed tag disagrees with `vntyper/version.py`.
-13. **`pyproject.toml` and the conda env disagree on numpy.** `pyproject.toml` pins
+13. **CI installs with `uv` into an explicit venv, never `--system`.** GitHub's
+    `ubuntu-24.04` image ships a PEP 668 "externally managed" interpreter, so
+    `uv pip install --system` fails outright with
+    `error: The interpreter at /usr is externally managed`. Every job therefore runs
+    `uv venv`, exports `VIRTUAL_ENV`, and appends `.venv/bin` to `$GITHUB_PATH` before
+    installing. Keep that three-line block if you add a job; `make ci-local-uv`
+    reproduces it locally, and it is the only local check that exercises the install
+    layer at all.
+14. **`pyproject.toml` and the conda env disagree on numpy.** `pyproject.toml` pins
     `numpy>=1.26.0,<2.0.0`; `conda/environment_vntyper.yml` installs `numpy=2.0.2`. The
     Dockerfile therefore installs the package with `pip install --no-deps`, or pip
     downgrades conda's numpy from PyPI and mixes provenance. Reconcile the two before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,16 @@ Neither exists — use the commands above.
 | Lint | `make lint` |
 | Type check | `make type-check` |
 | Fast tests (what CI runs) | `make test-unit` |
-| Integration tests | `make test-integration` |
-| Coverage | `make test-cov` |
+| Inner loop (fail-fast) | `make test-fast` |
+| Unit coverage + floor | `make test-unit-cov` |
+| Integration tests (needs 1.1 GB data) | `make test-integration` |
+| Full gate incl. integration | `make check-full` |
 | Docs preview | `make docs-serve` |
 | Docs build (CI-equivalent) | `make docs-build` |
 
-Always run `make check-all` before opening a PR. Run pytest **from the repo root** —
+Always run `make check-all` before opening a PR. It gates on the **unit** tier only
+(~0.5 s) so it is runnable on a fresh clone; use `make check-full` when you also want the
+tiers that need the 1.1 GB Zenodo archive. Run pytest **from the repo root** —
 `tests/parametrization.py` opens `tests/test_data_config.json` by relative path at
 collection time, so any other CWD breaks collection, including `-m unit`.
 
@@ -87,15 +91,76 @@ collection time, so any other CWD breaks collection, including `-m unit`.
 - Type hints are partial. Newer modules (`reference_registry`, `region_utils`,
   `scoring`, `flagging`) are fully annotated — match that when editing them.
 
+## Changing existing code
+
+These three rules apply whenever you touch a file, not just when you add a feature.
+
+**1. Touch a file, add tests for it.** This is not conditional on the module already
+having tests, and not something to defer to a follow-up PR.
+
+- Every function you **add** gets unit tests, including its failure paths.
+- Every function you **modify** gets a test that would have caught the bug you fixed, or
+  that pins the behaviour you changed. Write it *before* the fix where you can — a test
+  that fails first and passes after is worth more than one written to match the code.
+- Every function you **touch incidentally** (rename, refactor, re-indent) should leave
+  with at least the coverage it had.
+
+Tests go in the **unit** tier, so they must be pure: `tmp_path` + `unittest.mock`, no
+network, no Docker, no reference data, and `pytestmark = pytest.mark.unit` after the
+imports. If a change is only reachable through the integration tier, that is a signal the
+logic needs extracting — see rule 3.
+
+Two thresholds enforce this, and they are deliberately different:
+
+| | Where | Behaviour |
+| --- | --- | --- |
+| **Hard floor** | `fail_under` in `pyproject.toml` | CI **fails** below it. A ratchet — raise it when coverage climbs, never lower it to make a build pass. |
+| **Target: 80%** | `COVERAGE_TARGET` in the `Makefile` | **Warns** only. This is what the project is working towards. |
+
+`make test-unit-cov` reports both and prints the exact edit to raise the floor whenever
+coverage exceeds it. Never lower the floor to make a build pass — add the test instead.
+The gap between the two is real work, and rule 2 explains why it exists.
+
+**2. Keep files under ~650 LOC.** This is a real constraint here, not style preference.
+Measured on this repo, the correlation is total:
+
+| File | LOC | Unit coverage |
+| --- | --- | --- |
+| `cohort_summary.py` | 856 | 0% |
+| `cli.py` | 700 | 0% |
+| `generate_report.py` | 861 | 4% |
+| `pipeline.py` | 735 | 10% |
+| `install_references.py` | 901 | 24% |
+| `kestrel_genotyping.py` | 835 | 28% |
+| `region_utils.py` | 246 | 98% |
+| `scoring.py` | 176 | 100% |
+| `confidence_assignment.py` | 190 | 100% |
+
+Every module over 650 lines is under 30% covered; every well-covered module is under 650.
+Oversized files here are oversized because they fuse I/O, orchestration and pure logic
+into functions that cannot be called without a filesystem — which is exactly what makes
+them untestable. Splitting them is how the coverage gets written.
+
+**3. Refactor the part you touch.** When you edit inside a file over the limit, extract
+the region you are working on into a focused module rather than growing the file further.
+Pull the *pure* logic out first (parsing, scoring, filtering, formatting) and leave the
+I/O behind — the pure part is the part that gets a test. `scoring.py`,
+`confidence_assignment.py` and `region_utils.py` are the shape to copy. Do not attempt a
+whole-file rewrite as a side quest: split out the region under change, test it, move on.
+
+Known offenders, worst first: `docker/app/main.py` (1081), `install_references.py` (901),
+`generate_report.py` (861), `cohort_summary.py` (856), `kestrel_genotyping.py` (835),
+`pipeline.py` (735), `cli.py` (700), `tests/integration/test_pipeline_integration.py` (667).
+
 ## Testing
 
 - `pytest.ini` at the repo root is the live config. The `[tool.pytest.ini_options]`
   block in `pyproject.toml` is **dead** — pytest.ini takes precedence. Edit `pytest.ini`.
 - Markers: `unit`, `integration`, `docker`, `slow`.
 - **Every new unit test file must declare `pytestmark = pytest.mark.unit`.** CI runs
-  `pytest -m unit`, so an unmarked file silently never runs.
-  (`tests/unit/test_haplo_count_and_selection.py` is currently unmarked — 30 tests
-  invisible to CI.)
+  `pytest -m unit`, so an unmarked file silently never runs. This is enforced by
+  `tests/unit/test_marker_hygiene.py`, which fails the build naming the offending file;
+  `--strict-markers` additionally turns a *misspelled* marker into an error.
 - Unit tests must stay pure: `tmp_path` + `unittest.mock`, no network, no reference data.
 - Integration and docker tests pull a ~1.1 GB Zenodo archive and MD5 all 114 files; one
   missing file triggers a full re-download. There are **no** `pytest.skip` guards
@@ -149,12 +214,28 @@ collection time, so any other CWD breaks collection, including `-m unit`.
    differs. Do not upgrade the JAR.
 9. **`run_command` uses `shell=True`** deliberately, for process substitution in the CRAM
    unmapped-read path. Converting it to `shell=False` breaks that branch.
-10. **The Docker build clones from GitHub**, it does not build your local checkout. Only
-    `docker/entrypoint.sh` and `docker/app/` come from the local context.
+10. **The image is split in two, and the halves are bound by a content hash.**
+    `docker/Dockerfile.base` holds the conda envs, adVNTR and the reference genomes and
+    is rebuilt only by `docker-base.yml` when `conda/**`, `requirements-web.txt`,
+    `install_references*` or `dependencies/advntr/**` change. `docker/Dockerfile` holds
+    only the application and builds on top in ~3 min. Both workflows compute the same
+    `hashFiles()` tag, so changing a base input without publishing a new base makes the
+    app build **fail loudly** with a missing tag rather than silently using a stale base.
+    To change a base input: merge to `main` (or run `docker-base.yml` via
+    `workflow_dispatch`) so the base publishes first. Locally:
+    `make docker-build-base && make docker-build DOCKER_BASE_IMAGE=vntyper-base:local`.
+    (This replaced a `RUN git clone` of GitHub `main`, which meant PR builds never
+    tested PR code and a cached layer could serve an arbitrarily stale checkout.)
 11. **`vntyper report` is currently broken** — `cli.py` passes arguments
     `generate_summary_report()` does not accept. Do not copy that call site as an example.
 12. **Version lives in three places**: `vntyper/version.py` (authoritative),
-    `CITATION.cff`, and `docs/about/changelog.md` (currently stale at 2.0.1).
+    `CITATION.cff`, and `docs/about/changelog.md`. `publish-pypi.yml` refuses to publish
+    if the pushed tag disagrees with `vntyper/version.py`.
+13. **`pyproject.toml` and the conda env disagree on numpy.** `pyproject.toml` pins
+    `numpy>=1.26.0,<2.0.0`; `conda/environment_vntyper.yml` installs `numpy=2.0.2`. The
+    Dockerfile therefore installs the package with `pip install --no-deps`, or pip
+    downgrades conda's numpy from PyPI and mixes provenance. Reconcile the two before
+    removing `--no-deps`.
 
 ## Never
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,12 @@ Two thresholds enforce this, and they are deliberately different:
 coverage exceeds it. Never lower the floor to make a build pass — add the test instead.
 The gap between the two is real work, and rule 2 explains why it exists.
 
+**When raising the floor, use the number `make test-unit-cov` prints — never the `TOTAL`
+column of the coverage table.** Both that column and `coverage report --format=total`
+round to an integer, so a true 25.68% displays as `26%`; setting the floor from it makes
+CI fail on the very run that produced the number. The gate prints the precise figure and
+the exact line to paste.
+
 **2. Keep files under ~650 LOC.** This is a real constraint here, not style preference.
 Measured on this repo, the correlation is total:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,14 @@ Known offenders, worst first: `docker/app/main.py` (1081), `install_references.p
 
 - `pytest.ini` at the repo root is the live config. The `[tool.pytest.ini_options]`
   block in `pyproject.toml` is **dead** — pytest.ini takes precedence. Edit `pytest.ini`.
-- Markers: `unit`, `integration`, `docker`, `slow`.
+- Markers: `unit`, `integration`, `docker`, `smoke`, `slow`. `smoke` is the fast image
+  tier (`make test-docker-smoke`, ~1 s): it asserts the built image's *structure* — that
+  every reference path `config.json` declares actually exists in it, that the three conda
+  envs and their interpreters are present, that adVNTR imports under Python 2.7, and that
+  the image stays under its size budget. It needs a Docker daemon but **no test data**,
+  and it derives its assertions from the config inside the container rather than from a
+  hardcoded list, so it cannot drift. Smoke tests carry **only** the `smoke` marker —
+  adding `docker` too would make the slow tier re-run them.
 - **Every new unit test file must declare `pytestmark = pytest.mark.unit`.** CI runs
   `pytest -m unit`, so an unmarked file silently never runs. This is enforced by
   `tests/unit/test_marker_hygiene.py`, which fails the build naming the offending file;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,18 @@ Known offenders, worst first: `docker/app/main.py` (1081), `install_references.p
 12. **Version lives in three places**: `vntyper/version.py` (authoritative),
     `CITATION.cff`, and `docs/about/changelog.md`. `publish-pypi.yml` refuses to publish
     if the pushed tag disagrees with `vntyper/version.py`.
-13. **CI installs with `uv` into an explicit venv, never `--system`.** GitHub's
+13. **The package and the image must declare the same versions, and a test enforces it.**
+    `conda/environment_vntyper.yml` is what the Docker image *runs*; `pyproject.toml` is
+    what the PyPI package *declares*. When they disagree, `pip install .` inside the
+    image resolves something different from the recipe — that is not hypothetical:
+    pyproject pinned `numpy>=1.26.0,<2.0.0` while the env installed `numpy=2.0.2`, so the
+    published image silently ran 1.26.4 on a different numerical stack.
+    `tests/unit/test_version_consistency.py` fails the build if
+    a conda pin violates a pyproject specifier, if the image's Python is not in the CI
+    matrix, if the classifiers and matrix disagree, if ruff's `target-version` or mypy's
+    `python_version` drifts from `requires-python`, or if a binary the image smoke tier
+    requires is missing from the environment. Change versions in **both** files.
+14. **CI installs with `uv` into an explicit venv, never `--system`.** GitHub's
     `ubuntu-24.04` image ships a PEP 668 "externally managed" interpreter, so
     `uv pip install --system` fails outright with
     `error: The interpreter at /usr is externally managed`. Every job therefore runs

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-3679-1081"
 repository-code: "https://github.com/hassansaei/VNtyper"
 license: BSD-3-Clause
-version: "2.0.4"
+version: "2.0.5"
 date-released: "2026-08-05"
 doi: "10.5281/zenodo.19744166"
 identifiers:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VNtyper Makefile
 # Standardized development commands
 
-.PHONY: help install install-dev lint lint-stats format format-check type-check type-check-tests type-check-all download-test-data verify-test-data test test-unit test-fast test-unit-cov test-integration test-integration-parallel test-advntr test-cov test-quiet test-verbose test-docker test-docker-quick check check-all check-full clean build docker-build docker-build-base docker-clean docs-install docs-serve docs-build docs-check docs-clean
+.PHONY: help install install-dev lint lint-stats format format-check type-check type-check-tests type-check-all download-test-data verify-test-data test test-unit test-fast test-unit-cov test-integration test-integration-parallel test-advntr test-cov test-quiet test-verbose test-docker test-docker-quick check check-all check-full check-ci ci-local ci-local-docker ci-local-docs lint-actions lint-docker coverage-report test-docker-smoke clean build docker-build docker-build-base docker-clean docs-install docs-serve docs-build docs-check docs-clean
 
 # Colors for output
 BLUE := \033[0;34m
@@ -39,6 +39,14 @@ help:
 	@echo "  make test-cov                - Run tests with coverage report"
 	@echo "  make test-quiet              - Run tests with minimal output"
 	@echo "  make test-verbose            - Run tests with detailed output"
+	@echo ""
+	@echo "$(GREEN)Gates (run before opening a PR):$(RESET)"
+	@echo "  make check-all         - format + lint + mypy + unit tests (~4s)"
+	@echo "  make ci-local          - everything ci-tests.yml runs, locally"
+	@echo "  make ci-local-docker   - everything docker-build.yml runs, locally"
+	@echo "  make check-full        - check-all + integration tests (needs test data)"
+	@echo "  make lint-actions      - Lint GitHub Actions workflows (actionlint)"
+	@echo "  make lint-docker       - Lint Dockerfiles (BuildKit check)"
 	@echo ""
 	@echo "$(GREEN)Build & Maintenance:$(RESET)"
 	@echo "  make clean            - Remove build artifacts and cache"
@@ -145,13 +153,25 @@ test-fast:
 	@echo "$(BLUE)Running unit tests (fail-fast, last-failed first)...$(RESET)"
 	pytest -m unit tests/unit -o log_cli=false -q --ff -x
 
-# Coverage for the fast tier only. The floor is the measured baseline; ratchet it up
-# as coverage improves, never down.
+# Coverage for the fast tier.
+#
+# Two thresholds:
+#   HARD FLOOR - `fail_under` in pyproject.toml [tool.coverage.report]. CI fails below
+#                it. A ratchet: it only ever goes up.
+#   TARGET     - COVERAGE_TARGET below, what we are striving for. Falling short warns,
+#                never fails.
+# scripts/coverage_gate.py reports both and prints the exact edit to raise the floor
+# whenever coverage climbs past it.
+COVERAGE_TARGET ?= 80
+
 test-unit-cov:
 	@echo "$(BLUE)Running unit tests with coverage...$(RESET)"
-	pytest -m unit tests/unit -o log_cli=false \
-		--cov=vntyper --cov-report=term-missing --cov-fail-under=24
+	pytest -m unit tests/unit -o log_cli=false --cov --cov-report=term-missing
+	@python scripts/coverage_gate.py --target $(COVERAGE_TARGET)
 	@echo "$(GREEN)✓ Unit coverage complete$(RESET)"
+
+coverage-report:
+	@python scripts/coverage_gate.py --target $(COVERAGE_TARGET)
 
 test-integration:
 	@echo "$(BLUE)Running integration tests (with progress tracking)...$(RESET)"
@@ -226,6 +246,62 @@ check-all: format-check lint type-check-all test-unit
 # Opt-in gate that additionally runs the tiers needing test data / Docker.
 check-full: check-all test-integration
 	@echo "$(GREEN)✓ All checks passed (including integration)$(RESET)"
+
+# ---------------------------------------------------------------------------
+# Local CI parity
+# ---------------------------------------------------------------------------
+# `make ci-local` runs every check the GitHub Actions workflows run, so a red CI run
+# should never be the first time you learn something is broken. It deliberately mirrors
+# ci-tests.yml job for job.
+#
+# ACTIONLINT resolves to a local binary if present, otherwise the official container.
+ACTIONLINT ?= $(shell command -v actionlint 2>/dev/null)
+
+lint-actions:
+	@echo "$(BLUE)Linting GitHub Actions workflows...$(RESET)"
+	@if [ -n "$(ACTIONLINT)" ]; then \
+		$(ACTIONLINT); \
+	elif command -v docker >/dev/null 2>&1; then \
+		docker run --rm -v "$(PWD):/repo" --workdir /repo rhysd/actionlint:latest -color; \
+	else \
+		echo "$(RED)actionlint not found and Docker unavailable.$(RESET)"; \
+		echo "Install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"; \
+		exit 1; \
+	fi
+	@echo "$(GREEN)✓ Workflows valid$(RESET)"
+
+lint-docker:
+	@echo "$(BLUE)Linting Dockerfiles (BuildKit check)...$(RESET)"
+	@docker build --check -f docker/Dockerfile.base . >/dev/null
+	@docker build --check -f docker/Dockerfile \
+		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) . >/dev/null
+	@echo "$(GREEN)✓ Dockerfiles valid$(RESET)"
+
+# The docs job in ci-tests.yml. Fails loudly rather than skipping when the docs extra
+# is missing - a silent skip would defeat the point of local CI parity.
+ci-local-docs:
+	@if python -c "import mkdocs" 2>/dev/null; then \
+		$(MAKE) --no-print-directory docs-check; \
+	else \
+		echo "$(RED)mkdocs is not installed, so the CI docs job was NOT verified.$(RESET)"; \
+		echo "  Fix: pip install -e '.[docs]'"; \
+		exit 1; \
+	fi
+
+# Mirrors ci-tests.yml: lint -> typecheck -> unit tests + coverage -> docs.
+ci-local: lint-actions format-check lint type-check-all test-unit-cov ci-local-docs
+	@echo ""
+	@echo "$(GREEN)========================================$(RESET)"
+	@echo "$(GREEN)✓ Local CI parity checks all passed$(RESET)"
+	@echo "$(GREEN)========================================$(RESET)"
+	@echo "Verified here: workflow syntax, format, lint, mypy, unit tests + coverage, docs."
+	@echo "NOT verified here (CI only):"
+	@echo "  - the Python 3.9-3.12 matrix; this ran your interpreter only"
+	@echo "  - the Docker image jobs -> run 'make ci-local-docker'"
+
+# Mirrors docker-build.yml. Needs a Docker daemon; builds and smoke-tests the image.
+ci-local-docker: lint-docker docker-build test-docker-smoke
+	@echo "$(GREEN)✓ Local Docker CI parity checks passed$(RESET)"
 
 # Docker targets
 #Docker configuration

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VNtyper Makefile
 # Standardized development commands
 
-.PHONY: help install install-dev lint lint-stats format format-check type-check type-check-tests type-check-all download-test-data verify-test-data test test-unit test-integration test-integration-parallel test-advntr test-cov test-quiet test-verbose test-docker test-docker-quick clean build docker-build docker-clean docs-install docs-serve docs-build docs-check docs-clean
+.PHONY: help install install-dev lint lint-stats format format-check type-check type-check-tests type-check-all download-test-data verify-test-data test test-unit test-fast test-unit-cov test-integration test-integration-parallel test-advntr test-cov test-quiet test-verbose test-docker test-docker-quick check check-all check-full clean build docker-build docker-build-base docker-clean docs-install docs-serve docs-build docs-check docs-clean
 
 # Colors for output
 BLUE := \033[0;34m
@@ -29,10 +29,12 @@ help:
 	@echo "$(GREEN)Testing:$(RESET)"
 	@echo "  make download-test-data      - Download test data from Zenodo (1.1GB, ~10-30 min)"
 	@echo "  make verify-test-data        - Verify test data exists and has correct checksums"
-	@echo "  make test                    - Run all tests (with live logging)"
-	@echo "  make test-unit               - Run unit tests only (fast)"
+	@echo "  make test                    - Run all tests (needs test data + Docker)"
+	@echo "  make test-unit               - Run unit tests only (fast, ~0.5s)"
+	@echo "  make test-fast               - Unit tests, fail-fast, last-failed first"
+	@echo "  make test-unit-cov           - Unit tests + coverage floor (CI gate)"
 	@echo "  make test-integration        - Run integration tests only (sequential)"
-	@echo "  make test-integration-parallel - Run integration tests in parallel (67-81% faster)"
+	@echo "  make test-integration-parallel - Run integration tests in parallel"
 	@echo "  make test-advntr             - Run adVNTR test only"
 	@echo "  make test-cov                - Run tests with coverage report"
 	@echo "  make test-quiet              - Run tests with minimal output"
@@ -43,7 +45,8 @@ help:
 	@echo "  make build            - Build distribution packages"
 	@echo ""
 	@echo "$(GREEN)Docker:$(RESET)"
-	@echo "  make docker-build      - Build multi-stage Docker image (production-ready)"
+	@echo "  make docker-build      - Build application image on the published base (~3 min)"
+	@echo "  make docker-build-base - Rebuild the base image (conda+refs, ~20-30 min)"
 	@echo "  make test-docker       - Run Docker integration tests with testcontainers"
 	@echo "  make test-docker-quick - Run Docker tests (excluding slow tests)"
 	@echo "  make docker-clean      - Remove all VNtyper Docker images"
@@ -134,8 +137,21 @@ test:
 
 test-unit:
 	@echo "$(BLUE)Running unit tests (fast)...$(RESET)"
-	pytest -m unit
+	pytest -m unit tests/unit -o log_cli=false
 	@echo "$(GREEN)✓ Unit tests complete$(RESET)"
+
+# Inner dev loop: last-failed first, stop at the first failure.
+test-fast:
+	@echo "$(BLUE)Running unit tests (fail-fast, last-failed first)...$(RESET)"
+	pytest -m unit tests/unit -o log_cli=false -q --ff -x
+
+# Coverage for the fast tier only. The floor is the measured baseline; ratchet it up
+# as coverage improves, never down.
+test-unit-cov:
+	@echo "$(BLUE)Running unit tests with coverage...$(RESET)"
+	pytest -m unit tests/unit -o log_cli=false \
+		--cov=vntyper --cov-report=term-missing --cov-fail-under=24
+	@echo "$(GREEN)✓ Unit coverage complete$(RESET)"
 
 test-integration:
 	@echo "$(BLUE)Running integration tests (with progress tracking)...$(RESET)"
@@ -143,14 +159,16 @@ test-integration:
 	pytest -m integration
 	@echo "$(GREEN)✓ Integration tests complete$(RESET)"
 
+# --dist load, NOT loadfile: all 11 integration tests live in a single file, so
+# loadfile assigned every test to one worker and idled the rest.
 test-integration-parallel:
 	@echo "$(BLUE)Running integration tests in parallel (auto-detect CPU cores)...$(RESET)"
-	@echo "$(BLUE)Using pytest-xdist for parallel execution (67-81% faster)$(RESET)"
+	@echo "$(BLUE)Using pytest-xdist for parallel execution$(RESET)"
 	@if ! python -c "import xdist" 2>/dev/null; then \
 		echo "$(RED)Error: pytest-xdist not installed. Run: pip install -e .[dev]$(RESET)"; \
 		exit 1; \
 	fi
-	pytest -n auto --dist loadfile -m integration -v
+	pytest -n auto --dist load -m integration -v
 	@echo "$(GREEN)✓ Integration tests complete (parallel mode)$(RESET)"
 
 test-advntr:
@@ -195,11 +213,19 @@ build:
 all: format lint type-check test
 	@echo "$(GREEN)✓ All checks passed$(RESET)"
 
-check: format-check type-check test
+# check / check-all gate on the UNIT tier only, so they are runnable on a fresh clone.
+# They used to depend on `test` (bare pytest), which pulls in the integration tier
+# (needs a 1.1 GB Zenodo download) and the docker tier (needs a daemon + image build)
+# - i.e. the documented pre-PR command could not actually be run.
+check: format-check type-check test-unit
 	@echo "$(GREEN)✓ All checks passed$(RESET)"
 
-check-all: format-check lint type-check-all test
+check-all: format-check lint type-check-all test-unit
 	@echo "$(GREEN)✓ All checks passed (full suite)$(RESET)"
+
+# Opt-in gate that additionally runs the tiers needing test data / Docker.
+check-full: check-all test-integration
+	@echo "$(GREEN)✓ All checks passed (including integration)$(RESET)"
 
 # Docker targets
 #Docker configuration
@@ -207,11 +233,28 @@ DOCKER_IMAGE_NAME := vntyper
 DOCKER_IMAGE_TAG := latest
 DOCKER_IMAGE := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
+# The image is split in two. docker/Dockerfile.base carries the conda environments,
+# adVNTR and the reference genomes (expensive, changes a few times a year);
+# docker/Dockerfile carries only the application (~3 min).
+#
+# BASE_IMAGE defaults to the published ghcr base, so `make docker-build` alone works
+# and just pulls it. Build the base locally only when you are changing conda/**,
+# the reference config, or Dockerfile.base itself.
+DOCKER_BASE_IMAGE ?= ghcr.io/hassansaei/vntyper-base:latest
+
+docker-build-base:
+	@echo "$(BLUE)Building base image (conda envs + adVNTR + references)...$(RESET)"
+	@echo "$(BLUE)Note: this downloads and BWA-indexes reference genomes; expect 20-30 min$(RESET)"
+	DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.base -t vntyper-base:local .
+	@echo "$(GREEN)✓ Base image built: vntyper-base:local$(RESET)"
+	@echo "$(GREEN)  Now run: make docker-build DOCKER_BASE_IMAGE=vntyper-base:local$(RESET)"
+
 docker-build:
-	@echo "$(BLUE)Building Docker image (multi-stage production build)...$(RESET)"
-	DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t $(DOCKER_IMAGE) .
+	@echo "$(BLUE)Building application image on $(DOCKER_BASE_IMAGE)...$(RESET)"
+	DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile \
+		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
+		-t $(DOCKER_IMAGE) .
 	@echo "$(GREEN)✓ Docker image built: $(DOCKER_IMAGE)$(RESET)"
-	@echo "$(GREEN)✓ Image uses multi-stage build (35% smaller, more secure)$(RESET)"
 
 test-docker:
 	@echo "$(BLUE)Running all Docker integration tests with testcontainers...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ help:
 	@echo "  make docker-build      - Build application image on the published base (~3 min)"
 	@echo "  make docker-build-base - Rebuild the base image (conda+refs, ~20-30 min)"
 	@echo "  make test-docker       - Run Docker integration tests with testcontainers"
+	@echo "  make test-docker-smoke - Fast image structure checks (~1s, no test data)"
 	@echo "  make test-docker-quick - Run Docker tests (excluding slow tests)"
 	@echo "  make docker-clean      - Remove all VNtyper Docker images"
 	@echo ""
@@ -331,6 +332,14 @@ docker-build:
 		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 		-t $(DOCKER_IMAGE) .
 	@echo "$(GREEN)✓ Docker image built: $(DOCKER_IMAGE)$(RESET)"
+
+# Fast structural checks against an already-built image. No Zenodo test data, no
+# network inside the container, ~2s. Set VNTYPER_TEST_IMAGE to point at a tag other
+# than vntyper:local.
+test-docker-smoke:
+	@echo "$(BLUE)Running image structure smoke tests (no test data needed)...$(RESET)"
+	pytest -m smoke tests/docker -o log_cli=false
+	@echo "$(GREEN)✓ Image smoke tests complete$(RESET)"
 
 test-docker:
 	@echo "$(BLUE)Running all Docker integration tests with testcontainers...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -272,10 +272,18 @@ lint-actions:
 	fi
 	@echo "$(GREEN)✓ Workflows valid$(RESET)"
 
+# `docker build --check` needs BuildKit and Docker Engine >= 25. Detect it and fail
+# with the actual remedy, rather than surfacing an opaque "unknown flag" error.
 lint-docker:
 	@echo "$(BLUE)Linting Dockerfiles (BuildKit check)...$(RESET)"
-	@docker build --check -f docker/Dockerfile.base . >/dev/null
-	@docker build --check -f docker/Dockerfile \
+	@if ! docker build --help 2>/dev/null | grep -q -- '--check'; then \
+		echo "$(RED)This Docker Engine does not support 'docker build --check'.$(RESET)"; \
+		echo "  It needs BuildKit and Docker Engine 25 or newer; CI runs 28.x."; \
+		echo "  Upgrade Docker, or run 'make docker-build' alone to skip this lint."; \
+		exit 1; \
+	fi
+	@DOCKER_BUILDKIT=1 docker build --check -f docker/Dockerfile.base . >/dev/null
+	@DOCKER_BUILDKIT=1 docker build --check -f docker/Dockerfile \
 		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) . >/dev/null
 	@echo "$(GREEN)✓ Dockerfiles valid$(RESET)"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # VNtyper Makefile
 # Standardized development commands
 
-.PHONY: help install install-dev lint lint-stats format format-check type-check type-check-tests type-check-all download-test-data verify-test-data test test-unit test-fast test-unit-cov test-integration test-integration-parallel test-advntr test-cov test-quiet test-verbose test-docker test-docker-quick check check-all check-full check-ci ci-local ci-local-docker ci-local-docs lint-actions lint-docker coverage-report test-docker-smoke clean build docker-build docker-build-base docker-clean docs-install docs-serve docs-build docs-check docs-clean
+.PHONY: help install install-dev lint lint-stats format format-check type-check type-check-tests type-check-all download-test-data verify-test-data test test-unit test-fast test-unit-cov test-integration test-integration-parallel test-advntr test-cov test-quiet test-verbose test-docker test-docker-quick check check-all check-full check-ci ci-local ci-local-docker ci-local-docs ci-local-uv lint-actions lint-docker coverage-report test-docker-smoke clean build docker-build docker-build-base docker-clean docs-install docs-serve docs-build docs-check docs-clean
 
 # Colors for output
 BLUE := \033[0;34m
@@ -43,6 +43,7 @@ help:
 	@echo "$(GREEN)Gates (run before opening a PR):$(RESET)"
 	@echo "  make check-all         - format + lint + mypy + unit tests (~4s)"
 	@echo "  make ci-local          - everything ci-tests.yml runs, locally"
+	@echo "  make ci-local-uv       - replicate CI's uv install path in a temp venv"
 	@echo "  make ci-local-docker   - everything docker-build.yml runs, locally"
 	@echo "  make check-full        - check-all + integration tests (needs test data)"
 	@echo "  make lint-actions      - Lint GitHub Actions workflows (actionlint)"
@@ -289,8 +290,35 @@ ci-local-docs:
 		exit 1; \
 	fi
 
-# Mirrors ci-tests.yml: lint -> typecheck -> unit tests + coverage -> docs.
-ci-local: lint-actions format-check lint type-check-all test-unit-cov ci-local-docs
+# Replicates the INSTALL path CI uses (astral-sh/setup-uv -> uv venv -> uv pip install)
+# in a throwaway venv, then runs the same test command.
+#
+# This exists because `ci-local` runs in whatever environment you already have, so it
+# cannot catch breakage in how CI *builds* its environment. It missed exactly that once:
+# `uv pip install --system` fails on Ubuntu's PEP 668 interpreter
+# ("error: The interpreter at /usr is externally managed") and every CI job died at the
+# install step while every local check was green.
+CI_LOCAL_VENV := .ci-local-venv
+
+ci-local-uv:
+	@command -v uv >/dev/null 2>&1 || { \
+		echo "$(RED)uv not installed - cannot verify the CI install path.$(RESET)"; \
+		echo "  Fix: curl -LsSf https://astral.sh/uv/install.sh | sh"; \
+		exit 1; \
+	}
+	@echo "$(BLUE)Replicating the CI install path with uv...$(RESET)"
+	@rm -rf $(CI_LOCAL_VENV)
+	uv venv $(CI_LOCAL_VENV)
+	VIRTUAL_ENV=$(PWD)/$(CI_LOCAL_VENV) uv pip install -e ".[dev]"
+	@echo "$(BLUE)Running the CI test command in that environment...$(RESET)"
+	VIRTUAL_ENV=$(PWD)/$(CI_LOCAL_VENV) PATH="$(PWD)/$(CI_LOCAL_VENV)/bin:$$PATH" \
+		$(MAKE) --no-print-directory test-unit-cov
+	@rm -rf $(CI_LOCAL_VENV)
+	@echo "$(GREEN)✓ CI install path verified$(RESET)"
+
+# Mirrors ci-tests.yml: lint -> typecheck -> unit tests + coverage -> docs, plus a
+# from-scratch install exactly as CI builds it.
+ci-local: lint-actions format-check lint type-check-all test-unit-cov ci-local-docs ci-local-uv
 	@echo ""
 	@echo "$(GREEN)========================================$(RESET)"
 	@echo "$(GREEN)✓ Local CI parity checks all passed$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -336,11 +336,36 @@ ci-local: lint-actions format-check lint type-check-all test-unit-cov ci-local-d
 	@echo "  - the Python 3.9-3.12 matrix; this ran your interpreter only"
 	@echo "  - the Docker image jobs -> run 'make ci-local-docker'"
 
-# Mirrors docker-build.yml. Needs a Docker daemon; builds and smoke-tests the image.
-# VNTYPER_TEST_IMAGE is forced to the image just built - otherwise the smoke tier
-# would fall back to its default tag and silently test a different, older image.
-ci-local-docker: lint-docker docker-build
+# Files whose contents define the base image. CI hashes exactly this set; keep in sync
+# with the hashFiles() list in docker-base.yml (tests/unit/test_version_consistency.py
+# and test_workflow_consistency.py guard the pieces that can drift).
+BASE_INPUTS := conda docker/Dockerfile.base docker/requirements-web.txt \
+	vntyper/scripts/install_references.py vntyper/scripts/install_references_config.json \
+	vntyper/dependencies/advntr reference .dockerignore
+
+# Mirrors docker-build.yml. Needs a Docker daemon.
+#
+# VNTYPER_TEST_IMAGE is forced to the image just built - otherwise the smoke tier would
+# fall back to its default tag and silently test a different, older image.
+#
+# If you have edited a base input, building on the published :latest base tests
+# something CI will not build, so refuse rather than give false assurance.
+ci-local-docker: lint-docker
+	@if git rev-parse --verify -q origin/main >/dev/null 2>&1 && \
+	    ! git diff --quiet origin/main -- $(BASE_INPUTS) 2>/dev/null; then \
+		if [ "$(DOCKER_BASE_IMAGE)" = "ghcr.io/hassansaei/vntyper-base:latest" ]; then \
+			echo "$(RED)You changed a base image input, but DOCKER_BASE_IMAGE still points at the published :latest.$(RESET)"; \
+			echo "  CI will build a new base from your changes; this would not. Run:"; \
+			echo "    make docker-build-base"; \
+			echo "    make ci-local-docker DOCKER_BASE_IMAGE=vntyper-base:local"; \
+			exit 1; \
+		fi; \
+		echo "$(BLUE)Base inputs changed; using $(DOCKER_BASE_IMAGE)$(RESET)"; \
+	fi
+	@$(MAKE) --no-print-directory docker-build
 	@$(MAKE) --no-print-directory test-docker-smoke VNTYPER_TEST_IMAGE=$(DOCKER_IMAGE)
+	@echo "$(BLUE)Running the Docker tier CI runs on PRs...$(RESET)"
+	@$(MAKE) --no-print-directory test-docker-quick VNTYPER_TEST_IMAGE=$(DOCKER_IMAGE)
 	@echo "$(GREEN)✓ Local Docker CI parity checks passed$(RESET)"
 
 # Docker targets
@@ -388,7 +413,7 @@ test-docker:
 		echo "$(RED)Error: testcontainers not installed. Run: pip install -e .[dev]$(RESET)"; \
 		exit 1; \
 	fi
-	pytest -m docker -v
+	$(if $(VNTYPER_TEST_IMAGE),VNTYPER_TEST_IMAGE=$(VNTYPER_TEST_IMAGE)) pytest -m docker -v
 	@echo "$(GREEN)✓ Docker tests complete$(RESET)"
 
 test-docker-quick:
@@ -398,6 +423,7 @@ test-docker-quick:
 		echo "$(RED)Error: testcontainers not installed. Run: pip install -e .[dev]$(RESET)"; \
 		exit 1; \
 	fi
+	$(if $(VNTYPER_TEST_IMAGE),VNTYPER_TEST_IMAGE=$(VNTYPER_TEST_IMAGE)) \
 	pytest "tests/docker/test_docker_pipeline.py::test_docker_bam_pipeline[example_b178_hg19_subset_fast]" \
 	       "tests/docker/test_docker_pipeline.py::test_docker_container_health" \
 	       "tests/docker/test_docker_pipeline.py::test_docker_volume_mounts" \

--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,10 @@ ci-local: lint-actions format-check lint type-check-all test-unit-cov ci-local-d
 	@echo "  - the Docker image jobs -> run 'make ci-local-docker'"
 
 # Mirrors docker-build.yml. Needs a Docker daemon; builds and smoke-tests the image.
-ci-local-docker: lint-docker docker-build test-docker-smoke
+# VNTYPER_TEST_IMAGE is forced to the image just built - otherwise the smoke tier
+# would fall back to its default tag and silently test a different, older image.
+ci-local-docker: lint-docker docker-build
+	@$(MAKE) --no-print-directory test-docker-smoke VNTYPER_TEST_IMAGE=$(DOCKER_IMAGE)
 	@echo "$(GREEN)✓ Local Docker CI parity checks passed$(RESET)"
 
 # Docker targets
@@ -337,8 +340,9 @@ docker-build:
 # network inside the container, ~2s. Set VNTYPER_TEST_IMAGE to point at a tag other
 # than vntyper:local.
 test-docker-smoke:
-	@echo "$(BLUE)Running image structure smoke tests (no test data needed)...$(RESET)"
-	pytest -m smoke tests/docker -o log_cli=false
+	@echo "$(BLUE)Running image structure smoke tests on $(or $(VNTYPER_TEST_IMAGE),vntyper:local)...$(RESET)"
+	VNTYPER_TEST_IMAGE=$(or $(VNTYPER_TEST_IMAGE),vntyper:local) \
+		pytest -m smoke tests/docker -o log_cli=false
 	@echo "$(GREEN)✓ Image smoke tests complete$(RESET)"
 
 test-docker:

--- a/conda/environment_vntyper.yml
+++ b/conda/environment_vntyper.yml
@@ -4,23 +4,32 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - python=3.9.19
+  # Python 3.12: 3.9 reached end of life on 2025-10-31 and no longer receives security
+  # fixes. The versions below are exactly what conda-forge/bioconda resolve to for
+  # 3.12, pinned so the environment stays reproducible.
+  #
+  # Everything on the NUMERICAL path is unchanged from the 3.9 environment - bwa,
+  # samtools, fastp, bcftools, openjdk (which runs Kestrel), pysam, numpy, pandas and
+  # biopython are all identical versions - so genotyping output is unaffected by the
+  # interpreter bump. Only the reporting stack moved: matplotlib 3.9.2 -> 3.10.9,
+  # plotly 5.24.0 -> 6.9.0, igv-reports 1.13.0 -> 1.16.0, jinja2 3.1.4 -> 3.1.6.
+  - python=3.12.13
   - bioconda::bwa=0.7.18
   - samtools=1.20
   - bioconda::fastp=0.23.4
   - pandas=2.2.2
   - numpy=2.0.2
-  - regex=2024.7.24
+  - regex=2026.7.19
   - biopython=1.84
-  - setuptools=72.2.0
-  - jinja2=3.1.4
-  - ca-certificates=2024.7.4
-  - openssl=3.3.2
-  - matplotlib=3.9.2
+  - setuptools=83.0.0
+  - jinja2=3.1.6
+  - ca-certificates=2026.7.22
+  - openssl=3.6.3
+  - matplotlib=3.10.9
   - seaborn=0.13.2
-  - certifi=2024.8.30
-  - igv-reports=1.13.0
-  - plotly=5.24.0
+  - certifi=2026.7.22
+  - igv-reports=1.16.0
+  - plotly=6.9.0
   - openjdk=11.0.23
   - bcftools=1.21
   - pysam=0.22.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,203 +1,79 @@
 # syntax=docker/dockerfile:1.7
 # =============================================================================
-# VNtyper 2.0 - Multi-Stage Production Dockerfile
+# VNtyper application image - rebuilt on every commit
 # =============================================================================
-# Build Strategy:
-# - Stage 1: Base conda environment setup
-# - Stage 2: Build conda environments and compile dependencies
-# - Stage 3: Minimal runtime image with only necessary components
+# Layers onto ghcr.io/<owner>/vntyper-base, which carries the conda environments,
+# adVNTR and the reference genomes. Everything expensive lives there; this file only
+# installs the application, so it builds in ~3 minutes instead of 40-70.
 #
-# Expected outcome: 60-70% smaller image size, improved security
+# BASE_IMAGE is passed by .github/workflows/docker-build.yml as a content-addressed
+# tag derived from the base image's inputs, so a commit that changes conda/** cannot
+# accidentally build against a stale base - the tag simply will not exist and the
+# build fails loudly.
+#
+# Build locally with:
+#   docker build -f docker/Dockerfile.base -t vntyper-base:local .
+#   docker build -f docker/Dockerfile --build-arg BASE_IMAGE=vntyper-base:local -t vntyper:local .
 # =============================================================================
 
-# =============================================================================
-# Stage 1: Base Dependencies (Shared)
-# =============================================================================
-FROM condaforge/miniforge3:24.11.3-0@sha256:bcfc04b3562faa8dfd48f3767e2bd7b73a8529f9611b508d42e5bd227db1342d AS base
+ARG BASE_IMAGE=ghcr.io/hassansaei/vntyper-base:latest
 
-# OCI Labels for metadata
+FROM ${BASE_IMAGE} AS runtime
+
 LABEL org.opencontainers.image.title="VNtyper" \
       org.opencontainers.image.description="VNtyper 2.0 - MUC1 VNTR genotyping pipeline for ADTKD-MUC1" \
       org.opencontainers.image.vendor="VNtyper Project" \
-      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.licenses="BSD-3-Clause" \
       org.opencontainers.image.source="https://github.com/hassansaei/VNtyper" \
       org.opencontainers.image.url="https://github.com/hassansaei/VNtyper" \
-      org.opencontainers.image.documentation="https://github.com/hassansaei/VNtyper" \
+      org.opencontainers.image.documentation="https://hassansaei.github.io/VNtyper/" \
       com.vntyper.type="bioinformatics" \
       com.vntyper.pipeline="genotyping" \
-      com.vntyper.build="multistage"
+      com.vntyper.build="app"
 
-# Install mamba for faster package management
-RUN --mount=type=cache,target=/opt/conda/pkgs,sharing=locked \
-    conda install -y mamba -n base -c conda-forge && \
-    conda clean -afy
-
-# =============================================================================
-# Stage 2: Build Environment (Contains all build tools)
-# =============================================================================
-FROM base AS builder
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install build-time system dependencies with BuildKit cache
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        build-essential \
-        git \
-        wget \
-        unzip \
-        zip \
-        curl \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Define build arguments
-ARG REPO_URL=https://github.com/hassansaei/VNtyper.git
-ARG REPO_DIR=/opt/vntyper
-
-# Clone repository
-RUN git clone ${REPO_URL} ${REPO_DIR}
-
-WORKDIR ${REPO_DIR}
-
-# Copy environment files to temp location for better layer caching
-RUN cp conda/environment_vntyper.yml /tmp/environment_vntyper.yml && \
-    cp conda/environment_envadvntr.yml /tmp/environment_envadvntr.yml && \
-    cp conda/environment_shark.yml /tmp/environment_shark.yml
-
-# Create conda environments with aggressive cleanup
-# Using cache mounts to speed up repeated builds
-RUN --mount=type=cache,target=/opt/conda/pkgs,sharing=locked \
-    --mount=type=cache,target=/root/.conda/pkgs,sharing=locked \
-    mamba env create -f /tmp/environment_vntyper.yml && \
-    mamba env create -f /tmp/environment_envadvntr.yml && \
-    mamba env create -f /tmp/environment_shark.yml && \
-    conda clean -afy && \
-    find /opt/conda/envs -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true && \
-    find /opt/conda/envs -type f -name '*.pyc' -delete 2>/dev/null || true && \
-    find /opt/conda/envs -type f -name '*.pyo' -delete 2>/dev/null || true && \
-    rm -f /tmp/environment_*.yml
-
-# Install VNtyper Python package
-RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    conda run -n vntyper pip install .
-
-# Install adVNTR
-RUN chmod +x vntyper/dependencies/advntr/install_advntr.sh && \
-    bash -c "source /opt/conda/etc/profile.d/conda.sh && \
-    conda activate envadvntr && \
-    bash vntyper/dependencies/advntr/install_advntr.sh -o"
-
-# Install reference genomes
-RUN conda run -n vntyper vntyper --config-path /opt/vntyper/vntyper/config.json install-references \
-    --output-dir /opt/vntyper/reference
-
-# Extract adVNTR database if it was installed as a zip file
-# Do this in builder stage where we have proper Python environment
-RUN if [ -f /opt/vntyper/reference/vntr_db_advntr.zip ] && [ ! -d /opt/vntyper/reference/vntr_db_advntr ]; then \
-        echo "Extracting adVNTR database in builder stage..."; \
-        conda run -n vntyper python3 -c "import zipfile; z = zipfile.ZipFile('/opt/vntyper/reference/vntr_db_advntr.zip'); z.extractall('/opt/vntyper/reference'); print('Successfully extracted adVNTR database')" && \
-        echo "adVNTR database extracted successfully" || \
-        echo "WARNING: Failed to extract adVNTR database"; \
-    fi
-
-# Install FastAPI and web dependencies
-RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    conda run -n vntyper pip install \
-        "fastapi[standard]==0.115.3" \
-        "uvicorn[standard]==0.32.0" \
-        redis==5.2.0 \
-        celery==5.4.0 \
-        python-multipart==0.0.12 \
-        fastapi-limiter==0.1.6 \
-        email_validator==2.2.0 \
-        'passlib[bcrypt]==1.7.4' \
-        pydantic==2.10.0
-
-# Copy local entrypoint.sh and app directory to override cloned versions
-# This allows local development changes without pushing to GitHub
-# Note: Paths are relative to build context (repo root), not Dockerfile location
-COPY docker/entrypoint.sh /opt/vntyper/docker/entrypoint.sh
-COPY docker/app /opt/vntyper/app
-
-# =============================================================================
-# Stage 3: Minimal Runtime Image
-# =============================================================================
-FROM condaforge/miniforge3:24.11.3-0@sha256:bcfc04b3562faa8dfd48f3767e2bd7b73a8529f9611b508d42e5bd227db1342d AS runtime
-
-# Set environment variables
-ENV DEBIAN_FRONTEND=noninteractive \
-    CONDA_AUTO_UPDATE_CONDA=FALSE \
-    PATH=/opt/conda/envs/vntyper/bin:/opt/conda/envs/environment_vntyper/bin:$PATH \
-    DEFAULT_INPUT_DIR=/opt/vntyper/input \
-    DEFAULT_OUTPUT_DIR=/opt/vntyper/output \
-    REFERENCE_DIR=/opt/vntyper/reference
-
-# Install ONLY runtime dependencies (minimal set - no build tools!)
-# curl needed for health checks, ca-certificates for SSL
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        curl \
-        ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy conda environments from builder (this is where the magic happens!)
-# Conda environments are self-contained, so copying the entire envs directory works
-COPY --from=builder /opt/conda/envs /opt/conda/envs
-
-# Copy VNtyper application and references
-# Using --chown to set ownership during copy for better layer efficiency
-COPY --from=builder /opt/vntyper /opt/vntyper
-
-# Verify adVNTR database presence (should have been extracted in builder stage)
-RUN if [ -d /opt/vntyper/reference/vntr_db_advntr ]; then \
-        echo "adVNTR database found and ready"; \
-    else \
-        echo "INFO: adVNTR database not found - adVNTR module will not be available (this is optional)"; \
-    fi
-
-# Set working directory
 WORKDIR /opt/vntyper
 
-# Set up default directories
-RUN mkdir -p $DEFAULT_INPUT_DIR $DEFAULT_OUTPUT_DIR $REFERENCE_DIR
+# --- application package -----------------------------------------------------
+# Source comes from the build context, NOT a `git clone` of GitHub main. The old
+# Dockerfile cloned the repo, which meant (a) PR builds validated main rather than the
+# PR, and (b) the RUN layer's cache key never changed, so a cache hit could serve an
+# arbitrarily stale checkout.
+#
+# --no-deps is required: dependencies are conda-managed, and pyproject.toml pins
+# numpy>=1.26.0,<2.0.0 while conda/environment_vntyper.yml installs numpy=2.0.2. Without
+# --no-deps, pip pulls a second numpy from PyPI over the conda-managed one.
+COPY pyproject.toml README.md ./
+COPY vntyper/ ./vntyper/
+RUN conda run -n vntyper pip install --no-cache-dir --no-deps . && \
+    conda run -n vntyper vntyper --version
 
-# Create non-root user with configurable UID/GID
-ARG USERNAME=appuser
-ARG USER_UID=1001
-ARG USER_GID=1001
+# NOTE: deliberately NO `install-references` step here.
+#
+# The reference paths the pipeline actually reads - bwa_reference_hg19/hg38,
+# advntr_reference_vntr_*, muc1_*, code_adVNTR_RUs - are already correct RELATIVE paths
+# in the shipped config.json, and WORKDIR is /opt/vntyper with the references at
+# /opt/vntyper/reference. install_references.py's `--config-path` only adds `ucsc_*` /
+# `ncbi_*` absolute keys, which nothing in vntyper/ reads.
+#
+# Re-running it here is also actively harmful: `download_file` skips existing files but
+# decompression and MD5 run unconditionally, so it re-downloaded 148 MB and rewrote
+# ~508 MB of .fa on every application build - a 680 MB duplicated layer on top of the
+# base, for no change in behaviour.
+#
+# This also matches the previous single-stage image, where install-references patched the
+# source-tree config at /opt/vntyper/vntyper/config.json, never the installed copy that
+# cli.py actually loads via pkg_resources.
 
-RUN groupadd --gid $USER_GID $USERNAME && \
-    useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash --create-home $USERNAME
-
-# Set ownership of directories to non-root user
-RUN chown -R $USERNAME:$USERNAME \
-    $DEFAULT_INPUT_DIR \
-    $DEFAULT_OUTPUT_DIR \
-    $REFERENCE_DIR \
-    /opt/vntyper
-
-# Copy and set up entrypoint
-COPY --from=builder /opt/vntyper/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+# --- most volatile last ------------------------------------------------------
+COPY --chown=appuser:appuser docker/app/ /opt/vntyper/app/
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-# Copy FastAPI app
-COPY --from=builder /opt/vntyper/docker/app /opt/vntyper/app
-RUN chown -R $USERNAME:$USERNAME /opt/vntyper/app
-
-# Expose port
 EXPOSE 8000
 
-# Switch to non-root user
-USER $USERNAME
+USER appuser
 
-# Health check to verify container is running correctly
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD ["/usr/local/bin/entrypoint.sh", "health"]
 
-# Set entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,150 @@
+# syntax=docker/dockerfile:1.7
+# =============================================================================
+# VNtyper base image - the expensive, rarely-changing foundation
+# =============================================================================
+# Published as ghcr.io/<owner>/vntyper-base:<inputs-hash> by
+# .github/workflows/docker-base.yml, which only fires when the inputs below change:
+#
+#   conda/**                                    (the three conda environments)
+#   docker/requirements-web.txt                 (FastAPI/Celery stack)
+#   docker/Dockerfile.base                      (this file)
+#   vntyper/scripts/install_references*.{py,json}  (reference genomes + BWA indexes)
+#   vntyper/dependencies/advntr/**              (adVNTR build)
+#
+# Everything here is independent of application source, so editing vntyper/ or
+# docker/app/ never triggers a rebuild. The per-commit image (docker/Dockerfile)
+# layers onto this and builds in ~3 min instead of 40-70.
+#
+# NOTE ON CACHE MOUNTS: this file deliberately uses none. BuildKit does not export
+# `RUN --mount=type=cache` into any remote cache backend (gha or registry) - they are
+# builder-local state, and CI gets a fresh builder every job. The previous Dockerfile
+# had five of them; all were dead weight in CI. Worse, mounting a cache at
+# /opt/conda/pkgs put it on a different filesystem from /opt/conda/envs, which stops
+# conda hardlinking and silently added ~330 MB to the image.
+# =============================================================================
+
+ARG MINIFORGE=condaforge/miniforge3:24.11.3-0@sha256:bcfc04b3562faa8dfd48f3767e2bd7b73a8529f9611b508d42e5bd227db1342d
+
+# =============================================================================
+# Stage: envs - conda environments, web stack, compiled adVNTR
+# =============================================================================
+FROM ${MINIFORGE} AS envs
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# NOTE: condaforge/miniforge3:24.11.3-0 ALREADY ships mamba 1.5.12 and defaults to
+# solver=libmamba (verified: `mamba --version` in that exact digest). The old
+# Dockerfile ran `conda install -y mamba -n base -c conda-forge` here, which installed
+# nothing new but resolved against live conda-forge and silently floated the toolchain
+# (conda 24.11.3 -> 26.7.0, mamba 1.5.12 -> 2.8.1, a major version). That defeated the
+# @sha256 digest pin above and made builds non-reproducible. Do not re-add it.
+
+COPY conda/ /tmp/conda/
+RUN mamba env create -f /tmp/conda/environment_vntyper.yml && \
+    mamba env create -f /tmp/conda/environment_envadvntr.yml && \
+    mamba env create -f /tmp/conda/environment_shark.yml && \
+    conda clean -afy && \
+    find /opt/conda/envs -type d -name '__pycache__' -prune -exec rm -rf {} + 2>/dev/null || true && \
+    find /opt/conda/envs -type f \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) -delete 2>/dev/null || true && \
+    rm -rf /tmp/conda
+
+# Fully pinned and independent of application source, so this stays cached across
+# every application change.
+COPY docker/requirements-web.txt /tmp/requirements-web.txt
+RUN conda run -n vntyper pip install --no-cache-dir -r /tmp/requirements-web.txt && \
+    rm -f /tmp/requirements-web.txt
+
+# adVNTR compiles into the envadvntr (Python 2.7) environment's site-packages, so the
+# cloned build tree is disposable once `setup.py install` has run.
+COPY vntyper/dependencies/advntr/ /tmp/advntr/
+RUN bash -c "source /opt/conda/etc/profile.d/conda.sh && \
+        conda activate envadvntr && \
+        bash /tmp/advntr/install_advntr.sh -o -d /tmp/advntr-build" && \
+    rm -rf /tmp/advntr-build /tmp/advntr
+
+# =============================================================================
+# Stage: refs - reference genomes and BWA indexes
+# =============================================================================
+# Gated on only the two reference files, so a conda env change does not force a
+# 6-15 minute genome re-download and re-index.
+FROM envs AS refs
+
+# The tracked reference files that ship in the repo. These are NOT downloadable by
+# install_references.py and the pipeline needs them: muc1_region_hg19.fa for the SHARK
+# module (vntyper/modules/shark/shark_config.json) and vntr_db_advntr.zip for the adVNTR
+# databases named in config.json. The previous Dockerfile got them for free by cloning
+# the repo into the image; they now come from the build context.
+COPY reference/ /opt/refs/
+
+COPY vntyper/scripts/install_references.py \
+     vntyper/scripts/install_references_config.json \
+     /opt/ir/
+
+# No --config-path: the shipped config.json already carries correct RELATIVE reference
+# paths for this image's layout, and the ucsc_*/ncbi_* absolute keys it would add are
+# read by nothing in vntyper/. See the note in docker/Dockerfile.
+#
+# Files copied above are detected as already present and skipped. The two chr1 genomes
+# are downloaded and BWA-indexed here - the single most expensive step in the build,
+# and the main reason this image is separated from the per-commit one.
+RUN conda run -n vntyper python /opt/ir/install_references.py \
+        --output-dir /opt/refs \
+        --threads 4 && \
+    if [ -f /opt/refs/vntr_db_advntr.zip ] && [ ! -d /opt/refs/vntr_db_advntr ]; then \
+        conda run -n vntyper python -c "import zipfile; zipfile.ZipFile('/opt/refs/vntr_db_advntr.zip').extractall('/opt/refs')"; \
+    fi && \
+    test -d /opt/refs/vntr_db_advntr || { echo "adVNTR database missing after extraction"; exit 1; } && \
+    test -f /opt/refs/muc1_region_hg19.fa || { echo "SHARK muc1_region_hg19.fa missing"; exit 1; } && \
+    rm -f /opt/refs/alignment/*.fa.gz && \
+    rm -rf /opt/ir
+
+# =============================================================================
+# Stage: base - the published runtime foundation
+# =============================================================================
+FROM ${MINIFORGE} AS base
+
+LABEL org.opencontainers.image.title="VNtyper base" \
+      org.opencontainers.image.description="Conda environments, adVNTR and reference genomes for VNtyper" \
+      org.opencontainers.image.vendor="VNtyper Project" \
+      org.opencontainers.image.licenses="BSD-3-Clause" \
+      org.opencontainers.image.source="https://github.com/hassansaei/VNtyper" \
+      com.vntyper.type="bioinformatics" \
+      com.vntyper.build="base"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CONDA_AUTO_UPDATE_CONDA=FALSE \
+    PATH=/opt/conda/envs/vntyper/bin:$PATH \
+    DEFAULT_INPUT_DIR=/opt/vntyper/input \
+    DEFAULT_OUTPUT_DIR=/opt/vntyper/output \
+    REFERENCE_DIR=/opt/vntyper/reference
+
+# curl for the healthcheck, ca-certificates for TLS. No build tools in the runtime.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=appuser
+ARG USER_UID=1001
+ARG USER_GID=1001
+
+# `install -d -o` creates the two writable directories already owned by appuser.
+# The old Dockerfile ran `chown -R appuser /opt/vntyper` over 1.66 GB of references and
+# source; under overlayfs that copies up every touched file into a new layer, adding
+# ~1.66 GB to the image for nothing. References and code are read-only at runtime.
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash --create-home $USERNAME && \
+    install -d -o $USERNAME -g $USERNAME $DEFAULT_INPUT_DIR $DEFAULT_OUTPUT_DIR
+
+COPY --from=envs /opt/conda/envs /opt/conda/envs
+COPY --from=refs /opt/refs       /opt/vntyper/reference
+
+WORKDIR /opt/vntyper

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,22 +1,50 @@
 # VNtyper Docker Container
 
-A production-ready Docker container for **VNtyper** with multi-stage build optimization (60-70% smaller image size).
+A production-ready Docker container for **VNtyper**, built as two images:
+
+| Image | Contents | Rebuilt |
+| --- | --- | --- |
+| `docker/Dockerfile.base` | conda environments, adVNTR, reference genomes + BWA indexes | only when `conda/**`, `docker/requirements-web.txt`, `install_references*` or `vntyper/dependencies/advntr/**` change |
+| `docker/Dockerfile` | the VNtyper application and the FastAPI app | every commit (~3 min) |
+
+Splitting them keeps the per-commit build small: the expensive layers are published
+once to `ghcr.io/hassansaei/vntyper-base` and reused.
 
 ## **Building the Docker Image**
 
 ### **Quick Start**
 
 ```bash
-# Clone repository
 git clone https://github.com/hassansaei/VNtyper.git
 cd VNtyper
 
-# Build with BuildKit (recommended)
-DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t vntyper:latest .
-
-# Or use Make
+# Builds the application on the published base image (pulls the base, ~3 min)
 make docker-build
 ```
+
+Equivalently, by hand:
+
+```bash
+DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile \
+  --build-arg BASE_IMAGE=ghcr.io/hassansaei/vntyper-base:latest \
+  -t vntyper:latest .
+```
+
+### **Rebuilding the base image**
+
+Only needed when you change conda environments, the reference configuration, the web
+requirements, or `Dockerfile.base` itself. It downloads and BWA-indexes reference
+genomes, so expect 20-30 minutes.
+
+```bash
+make docker-build-base                                   # -> vntyper-base:local
+make docker-build DOCKER_BASE_IMAGE=vntyper-base:local   # build the app on it
+```
+
+In CI this happens automatically: `.github/workflows/docker-base.yml` publishes a base
+tagged with a content hash of those inputs, and `docker-build.yml` resolves the same
+hash. If you change a base input without publishing a new base, the app build fails
+with an explicit "base image does not exist" error rather than silently using a stale one.
 
 ### **Pull Pre-built Image**
 

--- a/docker/TESTING.md
+++ b/docker/TESTING.md
@@ -92,10 +92,16 @@ tests/
 
 ### How It Works
 
-1. **Session-Scoped Image Build** (`tests/docker/conftest.py:vntyper_image`)
-   - Builds Docker image once per pytest session
-   - Command: `docker build -f docker/Dockerfile -t vntyper:test .`
-   - Image is reused across all tests (efficient)
+1. **Session-Scoped Image** (`tests/docker/conftest.py:vntyper_image`)
+   - **Set `VNTYPER_TEST_IMAGE=<tag>` to use an existing image and skip building entirely.**
+     CI always does this, passing the image the build job just produced. Without it the
+     fixture rebuilds the whole image from scratch with no cache — measured at 1042s of
+     fixture setup to run 17s of assertions, which is why the Docker test jobs used to
+     take ~20 minutes.
+   - Falls back to `docker build -f docker/Dockerfile -t vntyper:test .` when the
+     variable is unset, so a developer with no image present still gets a working run.
+     Note this needs a base image; see `docker/README.md`.
+   - Image is reused across all tests in the session
 
 2. **Module-Scoped Container** (`tests/docker/conftest.py:vntyper_container`)
    - Creates running container with volume mounts

--- a/docker/requirements-web.txt
+++ b/docker/requirements-web.txt
@@ -1,0 +1,17 @@
+# Web-service dependencies for the FastAPI + Celery layer in docker/app/.
+#
+# Extracted verbatim from the inline `pip install` that used to live in
+# docker/Dockerfile. Kept as a separate file so the base image can install it as a
+# stable, fully pinned layer that does not depend on any application source - editing
+# vntyper/ no longer reinstalls fastapi.
+#
+# These are NOT part of the `vntyper` PyPI package; the CLI does not need them.
+fastapi[standard]==0.115.3
+uvicorn[standard]==0.32.0
+redis==5.2.0
+celery==5.4.0
+python-multipart==0.0.12
+fastapi-limiter==0.1.6
+email_validator==2.2.0
+passlib[bcrypt]==1.7.4
+pydantic==2.10.0

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -2,7 +2,36 @@
 
 All notable changes to VNtyper 2 are documented on this page.
 
-## 2.0.4 (Current)
+## 2.0.5 (Current)
+
+**Docker image now runs Python 3.12.** Python 3.9 reached end of life on 2025-10-31.
+Every package on the numerical path is unchanged - bwa, samtools, fastp, bcftools,
+openjdk (Kestrel), pysam, numpy, pandas and biopython all resolve to the same versions -
+and the pipeline reproduces the expected genotype exactly. Only the reporting stack
+moved (matplotlib, plotly, igv-reports, jinja2). The package now requires Python 3.10+
+and is tested on 3.10-3.13.
+
+**CI/CD pipeline rebuilt.** The Docker image is split into a rarely-rebuilt base
+(conda environments, adVNTR, reference genomes) and a per-commit application image, so a
+commit now rebuilds in about 3 minutes instead of 40-70. Images are published only after
+their tests pass, and the build uses the repository's own source rather than cloning
+GitHub, so a pull request now tests the code in that pull request.
+
+- Fixed `pyproject.toml` declaring `numpy<2.0.0` while the conda environment installed
+  numpy 2.0.2: `pip install .` inside the image downgraded conda's numpy, so the
+  published image ran a different numerical stack than its own recipe declared.
+- Fixed the TSV/CSV summary parsers silently truncating rows whose field count did not
+  match the header; a malformed row is now logged and skipped without discarding the
+  rest of the file.
+- Recovered 30 unit tests that carried no `unit` marker and had therefore never run in
+  CI, covering the Issue #136/#145 genotype tie-breaking logic.
+- Added a fast image smoke tier that verifies every reference path `config.json`
+  declares actually exists in the image.
+- Added coverage reporting with a ratcheting floor and an 80% target.
+- `make check-all` now runs in seconds and works on a fresh clone; it previously
+  required a 1.1 GB download and a Docker daemon.
+
+## 2.0.4
 
 - Migrated all logging to per-module loggers (`logging.getLogger(__name__)`); log
   records now carry the emitting module name instead of `root`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "vntyper"
 dynamic = ["version"]
 description = "VNtyper: A tool for genotyping MUC1-VNTR"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "BSD-3-Clause"}
 authors = [
     {name = "Hassan Saei", email = "hassan.saei@inserm.fr"},
@@ -19,16 +19,16 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
 ]
 dependencies = [
     "pandas>=2.2.0,<2.3.0",
-    "numpy>=1.26.0,<2.0.0",
+    "numpy>=1.26.0",
     "regex>=2024.7.24",
     "biopython>=1.84",
     "setuptools>=72.2.0",
@@ -100,8 +100,8 @@ version = {attr = "vntyper.version.__version__"}
 line-length = 120
 indent-width = 4
 
-# Target Python 3.9 (minimum supported version)
-target-version = "py39"
+# Target Python 3.10 (minimum supported version; 3.9 is EOL since 2025-10-31)
+target-version = "py310"
 
 # Exclude common directories
 exclude = [
@@ -181,9 +181,8 @@ unfixable = []
 # they hardcoded `--python-version 3.9`, and mypy 2.x dropped support for targeting
 # 3.9 ("must be 3.10 or higher"), breaking CI. Configure it once here instead.
 [tool.mypy]
-# The runtime floor stays 3.9 (see `requires-python` and the CI matrix); this is only
-# the version mypy type-checks against, and 3.10 is the oldest it still supports.
-# Ruff's `target-version = "py39"` remains the guard against 3.10+ syntax.
+# Matches `requires-python` and ruff's `target-version`; 3.10 is also the oldest
+# version mypy still supports targeting.
 python_version = "3.10"
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,15 +200,17 @@ show_missing = true
 # coverage climbs, never lower it to make a build pass. `make test-unit-cov` prints
 # the exact line to change when the floor is out of date.
 #
-# NOTE: `coverage report --format=total` ROUNDS to an integer, so it showed 25 when
-# the true figure was 24.51. scripts/coverage_gate.py reports the precise value via
-# coverage's Python API; keep this floor below it so both agree.
+# NOTE: BOTH `coverage report --format=total` AND pytest-cov's terminal TOTAL column
+# ROUND to an integer - a true 25.68% displays as 26%. Setting this floor from either
+# of those numbers makes CI fail on the very run that produced it. Take the value
+# `make test-unit-cov` prints instead: scripts/coverage_gate.py reports the precise
+# figure and states the exact line to paste here.
 #
 # The TARGET is 80% (COVERAGE_TARGET in the Makefile). Falling short of the target is
 # a warning, not a failure - see scripts/coverage_gate.py. The gap is deliberate: the
 # six modules over 650 LOC sit at 0-28% coverage and have to be split before they can
 # realistically be tested (see "Changing existing code" in AGENTS.md).
-fail_under = 26
+fail_under = 25
 exclude_also = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ show_missing = true
 # a warning, not a failure - see scripts/coverage_gate.py. The gap is deliberate: the
 # six modules over 650 LOC sit at 0-28% coverage and have to be split before they can
 # realistically be tested (see "Changing existing code" in AGENTS.md).
-fail_under = 24
+fail_under = 26
 exclude_also = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,11 +201,15 @@ show_missing = true
 # coverage climbs, never lower it to make a build pass. `make test-unit-cov` prints
 # the exact line to change when the floor is out of date.
 #
+# NOTE: `coverage report --format=total` ROUNDS to an integer, so it showed 25 when
+# the true figure was 24.51. scripts/coverage_gate.py reports the precise value via
+# coverage's Python API; keep this floor below it so both agree.
+#
 # The TARGET is 80% (COVERAGE_TARGET in the Makefile). Falling short of the target is
 # a warning, not a failure - see scripts/coverage_gate.py. The gap is deliberate: the
 # six modules over 650 LOC sit at 0-28% coverage and have to be split before they can
 # realistically be tested (see "Changing existing code" in AGENTS.md).
-fail_under = 25
+fail_under = 24
 exclude_also = [
     "if TYPE_CHECKING:",
     "raise NotImplementedError",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,31 @@ unfixable = []
 python_version = "3.10"
 ignore_missing_imports = true
 
+# ===========================
+# Coverage Configuration
+# ===========================
+[tool.coverage.run]
+# `source` must live here rather than on the CLI for relative_files to work.
+source = ["vntyper"]
+relative_files = true
+
+[tool.coverage.report]
+show_missing = true
+# HARD FLOOR - CI fails below this. It is a RATCHET: raise it whenever measured
+# coverage climbs, never lower it to make a build pass. `make test-unit-cov` prints
+# the exact line to change when the floor is out of date.
+#
+# The TARGET is 80% (COVERAGE_TARGET in the Makefile). Falling short of the target is
+# a warning, not a failure - see scripts/coverage_gate.py. The gap is deliberate: the
+# six modules over 650 LOC sit at 0-28% coverage and have to be split before they can
+# realistically be tested (see "Changing existing code" in AGENTS.md).
+fail_under = 25
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+]
+
 [tool.ruff.format]
 # Use double quotes (Python default)
 quote-style = "double"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ markers =
     integration: marks tests as integration tests
     unit: marks tests as unit tests
     docker: marks tests as Docker container tests (requires Docker daemon)
+    smoke: fast image structure checks (needs a Docker daemon, but no test data)
     slow: marks tests as slow-running tests (e.g., adVNTR module)
 
 # Exclude large data directories from test collection (major performance boost)

--- a/pytest.ini
+++ b/pytest.ini
@@ -44,10 +44,11 @@ log_level = DEBUG
 # ============================================================================
 # Test Timeout Configuration
 # ============================================================================
-# Timeout for integration tests (10 minutes) - prevents stuck tests
-# Requires: pip install pytest-timeout
-# timeout = 600
-# timeout_method = thread
+# Timeout for any single test (10 minutes) - prevents stuck tests burning the
+# full 6-hour GitHub Actions job limit. pytest-timeout is a pinned dev dependency
+# (pyproject.toml), so this needs no extra install.
+timeout = 600
+timeout_method = thread
 
 # ============================================================================
 # Test Output Configuration
@@ -55,5 +56,8 @@ log_level = DEBUG
 # Show extra test summary info
 console_output_style = progress
 
-# Show durations of slowest tests
-addopts = --durations=10 --durations-min=1.0
+# Show durations of slowest tests.
+# --durations-min must stay well below 1.0: the whole unit tier runs in ~0.5s, so a
+# 1.0s floor hid every duration and made perf regressions invisible.
+# --strict-markers turns a typo'd marker into an error instead of a silent deselect.
+addopts = --durations=15 --durations-min=0.05 --strict-markers

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Report unit-test coverage against a hard floor and a soft target.
+
+Two thresholds, deliberately different:
+
+* **Hard floor** (`fail_under` in ``pyproject.toml``) - CI fails below it. It exists to
+  stop regressions, and it is a ratchet: it only ever moves up.
+* **Soft target** (``--target``, 80% by default) - what the project is aiming for.
+  Falling short is a warning, never a failure.
+
+The floor is what makes the target reachable. Every time coverage climbs meaningfully
+above the floor, this script prints the exact edit to raise it, so the floor follows
+coverage upward instead of sitting at whatever it was set to years ago.
+
+Usage:
+    python scripts/coverage_gate.py [--target 80] [--ratchet-margin 1.0]
+
+Run it after a coverage run, i.e. once a .coverage data file exists.
+
+Exit codes:
+    0: at or above the hard floor (a warning is printed if below target)
+    1: below the hard floor, or coverage data could not be read
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def read_floor() -> float:
+    """Read the hard floor from ``[tool.coverage.report] fail_under``.
+
+    Returns:
+        float: The configured floor, or 0.0 if it cannot be found.
+    """
+    try:
+        text = PYPROJECT.read_text(encoding="utf-8")
+    except OSError:
+        return 0.0
+    match = re.search(r"^fail_under\s*=\s*([0-9.]+)", text, re.MULTILINE)
+    return float(match.group(1)) if match else 0.0
+
+
+def read_total() -> float | None:
+    """Read total coverage percentage from the existing coverage data file.
+
+    Returns:
+        Optional[float]: The total percentage, or None if coverage could not be read.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "coverage", "report", "--format=total"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode not in (0, 2):  # 2 = below fail_under, still prints a total
+        return None
+    try:
+        return float(result.stdout.strip())
+    except ValueError:
+        return None
+
+
+def emit(line: str, *, gh_command: str = "") -> None:
+    """Print a line, additionally annotating it for GitHub Actions when running in CI.
+
+    Args:
+        line: The human-readable message.
+        gh_command: One of "warning", "notice", "error", or "" for a plain line.
+    """
+    if gh_command and os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::{gh_command}::{line}")
+    else:
+        print(line)
+
+
+def write_summary(total: float, floor: float, target: float) -> None:
+    """Append a progress table to the GitHub Actions step summary, if available.
+
+    Args:
+        total: Measured coverage percentage.
+        floor: Hard floor percentage.
+        target: Soft target percentage.
+    """
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary:
+        return
+    filled = int(total / 100 * 40)
+    bar = "█" * filled + "░" * (40 - filled)
+    status = "✅ at target" if total >= target else "🎯 below target"
+    with open(summary, "a", encoding="utf-8") as handle:
+        handle.write(
+            f"### Unit test coverage\n\n"
+            f"`{bar}` **{total:.2f}%**\n\n"
+            f"| | % |\n| --- | --- |\n"
+            f"| Measured | **{total:.2f}** |\n"
+            f"| Hard floor (CI fails below) | {floor:.0f} |\n"
+            f"| Target | {target:.0f} — {status} |\n\n"
+        )
+
+
+def main() -> int:
+    """Compare measured coverage against the floor and the target.
+
+    Returns:
+        int: Process exit code.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target",
+        type=float,
+        default=80.0,
+        help="Soft target percentage to strive for (default: 80).",
+    )
+    parser.add_argument(
+        "--ratchet-margin",
+        type=float,
+        default=1.0,
+        help="Suggest raising the floor once coverage exceeds it by this many points.",
+    )
+    args = parser.parse_args()
+
+    floor = read_floor()
+    total = read_total()
+
+    if total is None:
+        emit(
+            "Could not read coverage data. Run a coverage command first, e.g. "
+            "`make test-unit-cov`.",
+            gh_command="error",
+        )
+        return 1
+
+    print(f"coverage {total:.2f}%  (floor {floor:.0f}%, target {args.target:.0f}%)")
+    write_summary(total, floor, args.target)
+
+    if total + 1e-9 < floor:
+        emit(
+            f"Coverage {total:.2f}% is below the hard floor of {floor:.0f}%. "
+            "Add tests for the code you changed; do not lower the floor.",
+            gh_command="error",
+        )
+        return 1
+
+    # The ratchet: lock in gains so the floor tracks reality and the target stays live.
+    if total >= floor + args.ratchet_margin:
+        emit(
+            f"Coverage {total:.2f}% now exceeds the floor of {floor:.0f}%. "
+            f"Raise it: set `fail_under = {int(total)}` in pyproject.toml "
+            "[tool.coverage.report].",
+            gh_command="notice",
+        )
+
+    if total < args.target:
+        emit(
+            f"Coverage {total:.2f}% is below the {args.target:.0f}% target "
+            f"({args.target - total:.2f} points to go). Not a failure - but any file you "
+            "touch should leave this higher than you found it.",
+            gh_command="warning",
+        )
+    else:
+        emit(f"Coverage {total:.2f}% meets the {args.target:.0f}% target.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -26,9 +26,9 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import io
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -53,24 +53,27 @@ def read_floor() -> float:
 def read_total() -> float | None:
     """Read total coverage percentage from the existing coverage data file.
 
+    Uses coverage.py's Python API rather than shelling out to `coverage report`. That
+    is faster, does not depend on the CLI being on PATH, and avoids spawning a
+    subprocess altogether.
+
     Returns:
         Optional[float]: The total percentage, or None if coverage could not be read.
     """
     try:
-        result = subprocess.run(
-            [sys.executable, "-m", "coverage", "report", "--format=total"],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except OSError:
+        import coverage
+    except ImportError:
         return None
-    if result.returncode not in (0, 2):  # 2 = below fail_under, still prints a total
-        return None
+
     try:
-        return float(result.stdout.strip())
-    except ValueError:
+        cov = coverage.Coverage(config_file=str(PYPROJECT))
+        cov.load()
+        # report() returns the total percentage; the text report itself is discarded.
+        # fail_under is enforced by this script, so ignore coverage's own exception.
+        return float(cov.report(file=io.StringIO()))
+    except Exception:
+        # A missing/corrupt .coverage file, or no measured data. Callers treat None as
+        # "could not read" and exit non-zero with an actionable message.
         return None
 
 

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -13,10 +13,27 @@ import os
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
-from typing import Optional
+from typing import Any
 
 import pytest
 from testcontainers.core.container import DockerContainer
+
+
+def _exit_code(result: Any) -> int:
+    """Return an exec result's exit code, treating an unknown code as failure.
+
+    testcontainers types `ExecResult.exit_code` as `int | None`; None means the daemon
+    did not report one (e.g. the exec was interrupted). Callers compare against 0, so
+    mapping None to a non-zero code keeps "unknown" from reading as success.
+
+    Args:
+        result: An exec result carrying an `exit_code` attribute.
+
+    Returns:
+        int: The exit code, or 1 when it is unknown.
+    """
+    code = getattr(result, "exit_code", None)
+    return 1 if code is None else int(code)
 
 
 @pytest.fixture(scope="session")
@@ -145,8 +162,8 @@ def run_vntyper_pipeline(
     bam_file: Path,
     reference: str,
     output_dir: Path,
-    extra_modules: Optional[list[str]] = None,
-    extra_cli_options: Optional[list[str]] = None,
+    extra_modules: list[str] | None = None,
+    extra_cli_options: list[str] | None = None,
 ) -> int:
     """
     Execute VNtyper pipeline inside Docker container.
@@ -194,7 +211,7 @@ def run_vntyper_pipeline(
     for i, part in enumerate(parts):
         if "docker_output" in part:
             # Everything after docker_output* is the subdirectory structure
-            subdir_parts = parts[i + 1:]
+            subdir_parts = parts[i + 1 :]
             if subdir_parts:
                 container_output_path = "/opt/vntyper/output/" + "/".join(subdir_parts)
             break
@@ -209,8 +226,10 @@ def run_vntyper_pipeline(
         ]
         mkdir_result = container.exec(mkdir_cmd)
         if mkdir_result.exit_code != 0:
-            print(f"Failed to create output directory: {mkdir_result.output.decode() if mkdir_result.output else 'No output'}")
-            return mkdir_result.exit_code
+            print(
+                f"Failed to create output directory: {mkdir_result.output.decode() if mkdir_result.output else 'No output'}"
+            )
+            return _exit_code(mkdir_result)
 
     # VNtyper writes log files next to input BAM, but input is read-only.
     # Copy BAM to output directory first (inside container).
@@ -250,7 +269,7 @@ def run_vntyper_pipeline(
     copy_result = container.exec(copy_cmd)
     if copy_result.exit_code != 0:
         print(f"Failed to copy BAM file: {copy_result.output.decode() if copy_result.output else 'No output'}")
-        return copy_result.exit_code
+        return _exit_code(copy_result)
 
     # Execute via conda run since we bypassed the entrypoint
     # Use --no-capture-output to stream stdout/stderr properly
@@ -270,16 +289,16 @@ def run_vntyper_pipeline(
         print(f"Output:\n{result.output.decode() if result.output else 'No output'}")
         print("=" * 80)
 
-    return result.exit_code
+    return _exit_code(result)
 
 
 def run_vntyper_fastq_pipeline(
     container: DockerContainer,
     fastq1: Path,
-    fastq2: Optional[Path],
+    fastq2: Path | None,
     reference: str,
     output_dir: Path,
-    extra_modules: Optional[list[str]] = None,
+    extra_modules: list[str] | None = None,
 ) -> int:
     """
     Execute VNtyper FASTQ pipeline inside Docker container.
@@ -338,4 +357,4 @@ def run_vntyper_fastq_pipeline(
         print(f"Output:\n{result.output.decode() if result.output else 'No output'}")
         print("=" * 80)
 
-    return result.exit_code
+    return _exit_code(result)

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -9,6 +9,7 @@ Fixtures:
 - vntyper_container: Module-scoped container with volume mounts
 """
 
+import os
 import subprocess
 from collections.abc import Generator
 from pathlib import Path
@@ -21,19 +22,27 @@ from testcontainers.core.container import DockerContainer
 @pytest.fixture(scope="session")
 def vntyper_image() -> Generator[str, None, None]:
     """
-    Build VNtyper Docker image once per test session.
+    Provide a VNtyper Docker image for the session, building one only if needed.
 
     Yields:
         str: Image tag
 
-    Notes:
-        - Built from project root Dockerfile
-        - Cached for entire test session
-        - Automatically cleaned up after session
-    """
-    import subprocess
+    Raises:
+        RuntimeError: If no image was supplied and the local build fails.
 
-    # Build image
+    Notes:
+        - Set VNTYPER_TEST_IMAGE to an existing tag to skip building entirely. CI does
+          this with the image the build job already produced and pushed; without it the
+          fixture rebuilt the whole image from scratch (measured: 1042s of fixture setup
+          to run 17s of assertions), which is why the Docker test jobs took ~20 minutes.
+        - The local build path is retained so `make test-docker` still works on a
+          developer machine with no image present.
+    """
+    preexisting = os.environ.get("VNTYPER_TEST_IMAGE")
+    if preexisting:
+        yield preexisting
+        return
+
     image_tag = "vntyper:test"
     project_root = Path(__file__).parent.parent.parent
 

--- a/tests/docker/image_probe.py
+++ b/tests/docker/image_probe.py
@@ -1,0 +1,152 @@
+"""
+In-container probe for the VNtyper image.
+
+Executed *inside* the image by tests/docker/test_image_structure.py, which pipes this
+file to the image's own interpreter and parses the single JSON document it writes to
+stdout. It runs under Python 3.9 with the standard library only: it must not import
+pytest, and it must not be collected by the host test run (hence no `test_` prefix).
+
+One container start covers every runtime assertion. Twenty `docker run` invocations
+would each re-pay interpreter startup on a 4.8 GB image; this pays it once and returns
+data that pytest turns into individually-named tests.
+
+Resolving config.json the way vntyper does - from the INSTALLED package, then relative
+to WORKDIR - is the whole point of this file. A hardcoded list of reference paths would
+drift from config.json, and that drift is precisely the bug this tier exists to catch.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+PREFIX = "/opt/vntyper"
+CONDA_ENVS = ("vntyper", "envadvntr", "shark_env")
+REQUIRED_BINARIES = ("bwa", "samtools", "fastp", "bcftools", "java")
+# `git` is deliberately absent: condaforge/miniforge3 ships it in its own layer, so
+# asserting on it would be a permanently red test we cannot fix from this Dockerfile.
+BUILD_TOOLS = ("gcc", "g++", "cc", "make", "ld")
+
+
+def _run(argv):
+    """Run argv and return a JSON-safe record rather than raising.
+
+    Args:
+        argv (list): Command to execute.
+
+    Returns:
+        dict: Keys ``rc``, ``out`` and ``err``.
+    """
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=60, check=False)
+        return {
+            "rc": proc.returncode,
+            "out": proc.stdout.strip(),
+            "err": proc.stderr.strip()[:300],
+        }
+    except Exception as exc:
+        return {"rc": 127, "out": "", "err": repr(exc)}
+
+
+def _entry(rel):
+    """Resolve a config-declared path the way the pipeline does, and stat it.
+
+    Args:
+        rel (str): Path as written in a shipped config file.
+
+    Returns:
+        dict: Declared path, resolved path, existence and size.
+    """
+    path = rel if os.path.isabs(rel) else os.path.join(PREFIX, rel)
+    exists = os.path.isfile(path)
+    return {
+        "declared": rel,
+        "resolved": path,
+        "exists": exists,
+        "size": os.path.getsize(path) if exists else 0,
+    }
+
+
+def _collect_references(pkg_dir, config):
+    """Collect every reference path the shipped configs declare, plus BWA sidecars.
+
+    Args:
+        pkg_dir (str): Directory of the installed ``vntyper`` package.
+        config (dict): Parsed ``config.json``.
+
+    Returns:
+        dict: Mapping of config key to a path record.
+    """
+    refs = {key: _entry(value) for key, value in sorted(config.get("reference_data", {}).items())}
+
+    shark_config = os.path.join(pkg_dir, "modules", "shark", "shark_config.json")
+    if os.path.isfile(shark_config):
+        with open(shark_config) as handle:
+            for key, rel in json.load(handle).get("shark_settings", {}).items():
+                if isinstance(rel, str) and rel.endswith((".fa", ".fasta")):
+                    refs["shark." + key] = _entry(rel)
+
+    # bwa_index_extensions is itself config-declared, so the sidecar set stays in sync
+    # with config.json rather than with a list maintained here.
+    extensions = config.get("tool_params", {}).get("bwa_index_extensions", [])
+    for assembly in ("hg19", "hg38"):
+        base = config.get("reference_data", {}).get("bwa_reference_" + assembly)
+        if base:
+            for ext in extensions:
+                refs[f"bwa_index_{assembly}{ext}"] = _entry(base + ext)
+
+    return refs
+
+
+def main():
+    """Emit a single JSON report describing the image's structure."""
+    import importlib.metadata as metadata
+
+    import vntyper
+
+    pkg_dir = os.path.dirname(vntyper.__file__)
+    with open(os.path.join(pkg_dir, "config.json")) as handle:
+        config = json.load(handle)
+
+    json.dump(
+        {
+            "uid": os.getuid(),
+            "gid": os.getgid(),
+            "package_version": metadata.version("vntyper"),
+            "cli_version": _run(["vntyper", "--version"]),
+            "conda_env_dirs": {env: os.path.isdir(f"/opt/conda/envs/{env}") for env in CONDA_ENVS},
+            # shark_env holds only bin/shark and has no interpreter, so only the two
+            # Python environments are probed for a version.
+            "interpreters": {
+                env: _run(
+                    [
+                        f"/opt/conda/envs/{env}/bin/python",
+                        "-c",
+                        "import sys;print('%d.%d' % sys.version_info[:2])",
+                    ]
+                )
+                for env in ("vntyper", "envadvntr")
+            },
+            "shark_binary": os.path.isfile("/opt/conda/envs/shark_env/bin/shark"),
+            "advntr_import": _run(
+                [
+                    "/opt/conda/envs/envadvntr/bin/python",
+                    "-c",
+                    "import advntr; print(advntr.__file__)",
+                ]
+            ),
+            "binaries": {name: shutil.which(name) for name in REQUIRED_BINARIES},
+            "leaked_build_tools": {name: shutil.which(name) for name in BUILD_TOOLS if shutil.which(name)},
+            "references": _collect_references(pkg_dir, config),
+            "kestrel_jar": bool(
+                [name for name in os.listdir(os.path.join(pkg_dir, "dependencies", "kestrel")) if name.endswith(".jar")]
+            )
+            if os.path.isdir(os.path.join(pkg_dir, "dependencies", "kestrel"))
+            else False,
+        },
+        sys.stdout,
+    )
+
+
+main()

--- a/tests/docker/test_image_structure.py
+++ b/tests/docker/test_image_structure.py
@@ -215,9 +215,9 @@ def test_conda_env_exists(probe: dict[str, Any], env: str) -> None:
     assert probe["conda_env_dirs"][env]
 
 
-@pytest.mark.parametrize(("env", "expected"), [("vntyper", "3.9"), ("envadvntr", "2.7")])
+@pytest.mark.parametrize(("env", "expected"), [("vntyper", "3.12"), ("envadvntr", "2.7")])
 def test_interpreter_version(probe: dict[str, Any], env: str, expected: str) -> None:
-    """adVNTR needs Python 2.7; the pipeline needs 3.9. Neither may drift.
+    """adVNTR needs Python 2.7; the pipeline needs 3.12. Neither may drift.
 
     Args:
         probe: Probe report.

--- a/tests/docker/test_image_structure.py
+++ b/tests/docker/test_image_structure.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+tests/docker/test_image_structure.py
+
+Fast structural smoke tests for the VNtyper application image.
+
+Complements tests/docker/test_docker_pipeline.py rather than replacing it. This tier
+needs no Zenodo test data and asserts only on the image's structure, so it runs on every
+PR in a couple of seconds; the pipeline tier still owns output correctness.
+
+Two fixtures, two costs:
+  - `image_metadata` reads image config from the daemon and starts no container at all.
+  - `probe` starts exactly ONE container, pipes image_probe.py to the image's own
+    interpreter, and returns the parsed JSON. Every runtime assertion below reads that
+    one blob, so twenty assertions cost one container start rather than twenty.
+
+Marked `smoke` only, NOT `docker`: `make test-docker` runs `-m docker`, so adding both
+markers would make the slow tier re-run all of these.
+
+These tests never build an image - see the note in conftest.py about a 1042s fixture.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+IMAGE = os.environ.get("VNTYPER_TEST_IMAGE", "vntyper:local")
+PROBE = Path(__file__).parent / "image_probe.py"
+
+# Generous on purpose. The image is ~4.8 GiB; this catches a regression of the class
+# documented in docker/Dockerfile (a 680 MB duplicated reference layer, a 1.66 GB
+# recursive chown), not ordinary drift. A tight budget is a flaky budget.
+MAX_IMAGE_BYTES = 6 * 1024**3
+
+# org.opencontainers.image.version and .ref.name are inherited from the Ubuntu base
+# ("20.04", "ubuntu") on local builds and only corrected by docker/metadata-action in
+# CI, so they are deliberately not asserted.
+REQUIRED_LABELS = (
+    "org.opencontainers.image.title",
+    "org.opencontainers.image.source",
+    "org.opencontainers.image.licenses",
+)
+REQUIRED_BINARIES = ("bwa", "samtools", "fastp", "bcftools", "java")
+
+# Floors, never equality: BWA index sizes shift with the indexer version. These only
+# need to catch a truncated download or a half-written layer.
+MIN_REFERENCE_BYTES = {
+    "bwa_reference_hg19": 200 * 1024**2,
+    "bwa_reference_hg38": 200 * 1024**2,
+}
+
+
+def _docker_available() -> bool:
+    """Report whether a usable Docker daemon is present.
+
+    Returns:
+        bool: True if the `docker` CLI exists and the daemon answers.
+    """
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "info"], capture_output=True, check=False).returncode == 0
+
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skipif(not _docker_available(), reason="Docker daemon not available"),
+]
+
+
+@pytest.fixture(scope="session")
+def image_metadata() -> dict[str, Any]:
+    """Return image configuration straight from the daemon; starts no container.
+
+    Returns:
+        dict: Parsed `docker image inspect` output.
+    """
+    result = subprocess.run(
+        ["docker", "image", "inspect", IMAGE],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"image {IMAGE} not present locally; set VNTYPER_TEST_IMAGE or build it first")
+    return json.loads(result.stdout)[0]
+
+
+@pytest.fixture(scope="session")
+def probe(image_metadata: dict[str, Any]) -> dict[str, Any]:
+    """Run image_probe.py inside the image once and return its JSON report.
+
+    `--network none` guarantees no assertion here can silently depend on Zenodo, UCSC
+    or conda-forge being reachable.
+
+    Args:
+        image_metadata: Ensures the image exists before a container is started.
+
+    Returns:
+        dict: The probe's report.
+    """
+    with PROBE.open("rb") as handle:
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-i",
+                "--network",
+                "none",
+                "--entrypoint",
+                "/opt/conda/envs/vntyper/bin/python",
+                IMAGE,
+                "-",
+            ],
+            stdin=handle,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode == 0, f"probe failed in {IMAGE}:\n{result.stderr}"
+    return json.loads(result.stdout)
+
+
+# --- image metadata: no container started ------------------------------------
+
+
+def test_runs_as_non_root(image_metadata: dict[str, Any]) -> None:
+    """The image must declare the unprivileged user."""
+    assert image_metadata["Config"]["User"] == "appuser"
+
+
+def test_healthcheck_declared(image_metadata: dict[str, Any]) -> None:
+    """A HEALTHCHECK must survive Dockerfile refactors."""
+    assert image_metadata["Config"]["Healthcheck"]["Test"][:1] == ["CMD"]
+
+
+def test_entrypoint_is_exec_form(image_metadata: dict[str, Any]) -> None:
+    """Exec form keeps signal handling intact under docker stop / k8s."""
+    assert image_metadata["Config"]["Entrypoint"] == ["/usr/local/bin/entrypoint.sh"]
+
+
+def test_port_exposed(image_metadata: dict[str, Any]) -> None:
+    """docker-compose and k8s wiring depend on the declared port."""
+    assert "8000/tcp" in image_metadata["Config"]["ExposedPorts"]
+
+
+def test_workdir_is_prefix(image_metadata: dict[str, Any]) -> None:
+    """config.json's reference paths are relative and resolve against WORKDIR."""
+    assert image_metadata["Config"]["WorkingDir"] == "/opt/vntyper"
+
+
+@pytest.mark.parametrize("label", REQUIRED_LABELS)
+def test_oci_label_present(image_metadata: dict[str, Any], label: str) -> None:
+    """Provenance labels for a published scientific tool.
+
+    Args:
+        image_metadata: Image config.
+        label: Label key that must be set.
+    """
+    assert image_metadata["Config"]["Labels"].get(label)
+
+
+def test_image_size_budget(image_metadata: dict[str, Any]) -> None:
+    """Fail loudly on a large size regression rather than discovering it in a registry."""
+    size = image_metadata["Size"]
+    assert size < MAX_IMAGE_BYTES, f"image is {size / 1024**3:.2f} GiB, budget is {MAX_IMAGE_BYTES / 1024**3:.2f} GiB"
+
+
+# --- runtime probe: one container start, shared by every test below ----------
+
+
+def test_uid_is_1001(probe: dict[str, Any]) -> None:
+    """Volume-mount permissions depend on the effective UID, not just Config.User."""
+    assert probe["uid"] == 1001
+
+
+def test_cli_version_matches_package(probe: dict[str, Any]) -> None:
+    """A bare --version proves the entry point runs; equality proves *what* ran.
+
+    Catches a failed `pip install --no-deps`, a stale layer cache serving an old
+    checkout, and a broken console-script entry point.
+    """
+    assert probe["cli_version"]["rc"] == 0, probe["cli_version"]["err"]
+    assert probe["cli_version"]["out"].split()[-1] == probe["package_version"]
+
+
+@pytest.mark.parametrize("env", ["vntyper", "envadvntr", "shark_env"])
+def test_conda_env_exists(probe: dict[str, Any], env: str) -> None:
+    """All three environments must survive the COPY --from into the runtime stage.
+
+    Args:
+        probe: Probe report.
+        env: Conda environment name.
+    """
+    assert probe["conda_env_dirs"][env]
+
+
+@pytest.mark.parametrize(("env", "expected"), [("vntyper", "3.9"), ("envadvntr", "2.7")])
+def test_interpreter_version(probe: dict[str, Any], env: str, expected: str) -> None:
+    """adVNTR needs Python 2.7; the pipeline needs 3.9. Neither may drift.
+
+    Args:
+        probe: Probe report.
+        env: Conda environment name.
+        expected: Expected major.minor version.
+    """
+    assert probe["interpreters"][env]["out"] == expected
+
+
+def test_shark_binary_present(probe: dict[str, Any]) -> None:
+    """shark_env ships a single C++ binary and no interpreter - assert what it is."""
+    assert probe["shark_binary"]
+
+
+def test_advntr_imports_under_py27(probe: dict[str, Any]) -> None:
+    """The compiled adVNTR egg is the most fragile artifact in the image.
+
+    It is built in a cloned tree that is deleted afterwards, so a broken .so would
+    otherwise only surface under `--extra-modules advntr` in the slow tier.
+    """
+    assert probe["advntr_import"]["rc"] == 0, probe["advntr_import"]["err"]
+
+
+@pytest.mark.parametrize("binary", REQUIRED_BINARIES)
+def test_binary_resolves(probe: dict[str, Any], binary: str) -> None:
+    """A conda solve that drops a tool is invisible until mid-pipeline.
+
+    Args:
+        probe: Probe report.
+        binary: Executable expected on PATH.
+    """
+    assert probe["binaries"][binary], f"{binary} is not on PATH in the image"
+
+
+def test_kestrel_jar_present(probe: dict[str, Any]) -> None:
+    """The Kestrel JAR is package-data; a packaging change can drop it silently."""
+    assert probe["kestrel_jar"]
+
+
+def test_no_compiler_leaked(probe: dict[str, Any]) -> None:
+    """Verify the multi-stage split held.
+
+    `git` is excluded on purpose - condaforge/miniforge3 installs it in its own layer,
+    so asserting on it would be permanently red. See image_probe.py.
+    """
+    assert probe["leaked_build_tools"] == {}
+
+
+def test_every_declared_reference_exists(probe: dict[str, Any]) -> None:
+    """The regression this whole tier exists for.
+
+    config.json names reference files that a .dockerignore rule, a changed COPY, or a
+    stale base image can silently omit - this actually happened: three paths
+    (both adVNTR databases and SHARK's muc1_region_hg19.fa) went missing when
+    .dockerignore excluded all of reference/. Nothing in the build failed, because
+    Dockerfile.base's `test -f` guards only run during a base build.
+    """
+    missing = {key: entry["resolved"] for key, entry in probe["references"].items() if not entry["exists"]}
+    assert not missing, f"config declares paths absent from the image: {missing}"
+
+
+@pytest.mark.parametrize(("key", "minimum"), sorted(MIN_REFERENCE_BYTES.items()))
+def test_reference_not_truncated(probe: dict[str, Any], key: str, minimum: int) -> None:
+    """Catch truncated downloads and half-written layers with a floor, never equality.
+
+    Args:
+        probe: Probe report.
+        key: config.json reference key.
+        minimum: Minimum plausible size in bytes.
+    """
+    assert probe["references"][key]["size"] >= minimum

--- a/tests/docker/test_image_structure.py
+++ b/tests/docker/test_image_structure.py
@@ -60,12 +60,25 @@ MIN_REFERENCE_BYTES = {
 def _docker_available() -> bool:
     """Report whether a usable Docker daemon is present.
 
+    This runs at collection time via the module-level skipif below, so it must never
+    block: a daemon that is present but wedged (starting up, or stuck on its socket)
+    would otherwise stall the whole test session. Treat non-responsive as unavailable.
+
     Returns:
-        bool: True if the `docker` CLI exists and the daemon answers.
+        bool: True if the `docker` CLI exists and the daemon answers within 10s.
     """
     if shutil.which("docker") is None:
         return False
-    return subprocess.run(["docker", "info"], capture_output=True, check=False).returncode == 0
+    try:
+        completed = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return completed.returncode == 0
 
 
 pytestmark = [

--- a/tests/unit/test_haplo_count_and_selection.py
+++ b/tests/unit/test_haplo_count_and_selection.py
@@ -19,6 +19,9 @@ import pytest
 
 from vntyper.scripts.kestrel_genotyping import add_haplo_count, select_single_best_variant
 
+# CI runs `pytest -m unit`; without this the whole file is silently skipped.
+pytestmark = pytest.mark.unit
+
 
 class TestAddHaploCount:
     """Test the add_haplo_count function."""

--- a/tests/unit/test_marker_hygiene.py
+++ b/tests/unit/test_marker_hygiene.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+tests/unit/test_marker_hygiene.py
+
+Guards the test suite against silently losing coverage in CI.
+
+CI runs `pytest -m unit`. A test file under tests/unit/ that forgets
+`pytestmark = pytest.mark.unit` is collected, deselected, and never run - with no
+warning and a green build. That is not hypothetical: test_haplo_count_and_selection.py
+sat unmarked with 30 passing tests covering the Issue #136/#145 genotype tie-breaking
+logic, invisible to CI.
+
+`--strict-markers` (pytest.ini) catches a *misspelled* marker but cannot catch a
+*missing* one. This test closes that gap.
+
+It works off the live session's collected items, so it costs no subprocess and no
+measurable time: any file that contributes zero items to a `-m unit` run is either
+unmarked or has no tests, and we distinguish those by source inspection.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+UNIT_DIR = Path(__file__).resolve().parent
+
+# A module defines tests if it has a top-level `def test_*` or a `class Test*`.
+_DEFINES_TESTS = re.compile(r"^\s*(?:async\s+def\s+test_|def\s+test_|class\s+Test)", re.MULTILINE)
+
+
+def test_every_unit_file_is_selected_by_the_unit_marker(request: pytest.FixtureRequest) -> None:
+    """Every test file under tests/unit/ must be selected by `pytest -m unit`.
+
+    Args:
+        request: Pytest request, used to reach the current session's collected items.
+
+    Raises:
+        AssertionError: If a file defining tests contributed no items to this run.
+    """
+    selected_files = {
+        Path(str(item.fspath)).resolve() for item in request.session.items if str(item.fspath).endswith(".py")
+    }
+
+    unmarked = []
+    for path in sorted(UNIT_DIR.glob("test_*.py")):
+        if path.resolve() in selected_files:
+            continue
+        if _DEFINES_TESTS.search(path.read_text(encoding="utf-8")):
+            unmarked.append(path.name)
+
+    assert not unmarked, (
+        "These files under tests/unit/ define tests but contributed nothing to a "
+        f"`pytest -m unit` run, so CI never executes them: {unmarked}. "
+        "Add `pytestmark = pytest.mark.unit` immediately after the imports."
+    )

--- a/tests/unit/test_summary_parsers.py
+++ b/tests/unit/test_summary_parsers.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+tests/unit/test_summary_parsers.py
+
+Unit tests for the TSV/CSV parsers in vntyper.scripts.summary.
+
+These parsers feed pipeline_summary.json, which generate_report.py and
+cohort_summary.py then read, so a silently mis-parsed row propagates into the report a
+clinician sees. The ragged-row behaviour is therefore pinned explicitly: a row whose
+field count disagrees with the header is skipped and logged, never truncated into a
+plausible-looking partial record, and never allowed to discard the rest of the file.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from vntyper.scripts.summary import parse_csv, parse_tsv
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path: Path, text: str) -> str:
+    """Write text to a file and return its path as a string.
+
+    Args:
+        path: Destination path.
+        text: File contents.
+
+    Returns:
+        str: The path, as the parsers expect.
+    """
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+# --- well-formed input -------------------------------------------------------
+
+
+def test_parse_tsv_reads_comments_and_rows(tmp_path: Path) -> None:
+    """Comment lines become comments; the first non-comment line is the header."""
+    path = _write(
+        tmp_path / "ok.tsv",
+        "# VNtyper Kestrel result\n# Version: 2.0.4\nMotifs\tPOS\tREF\nD-C\t67\tG\nD-A\t12\tT\n",
+    )
+    result = parse_tsv(path)
+
+    assert result["comments"] == ["VNtyper Kestrel result", "Version: 2.0.4"]
+    assert result["data"] == [
+        {"Motifs": "D-C", "POS": "67", "REF": "G"},
+        {"Motifs": "D-A", "POS": "12", "REF": "T"},
+    ]
+
+
+def test_parse_csv_reads_comments_and_rows(tmp_path: Path) -> None:
+    """The CSV parser treats a row whose first cell starts with '#' as a comment."""
+    path = _write(tmp_path / "ok.csv", "# header comment\nMotifs,POS\nD-C,67\n")
+    result = parse_csv(path)
+
+    assert result["comments"] == ["header comment"]
+    assert result["data"] == [{"Motifs": "D-C", "POS": "67"}]
+
+
+def test_parse_tsv_skips_blank_lines(tmp_path: Path) -> None:
+    """Blank lines are ignored rather than becoming empty records."""
+    path = _write(tmp_path / "blank.tsv", "A\tB\n\n1\t2\n\n")
+    assert parse_tsv(path)["data"] == [{"A": "1", "B": "2"}]
+
+
+# --- ragged rows: the behaviour this module pins -----------------------------
+
+
+@pytest.mark.parametrize(
+    ("row", "found"),
+    [("1\t2", 2), ("1\t2\t3\t4", 4)],
+    ids=["too-few-fields", "too-many-fields"],
+)
+def test_parse_tsv_skips_ragged_row_and_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, row: str, found: int
+) -> None:
+    """A ragged row is dropped with a warning naming the file and line.
+
+    Truncating it instead would produce a record that looks valid but is missing
+    columns - corruption that reaches the report unnoticed.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+        caplog: Log capture fixture.
+        row: The malformed row.
+        found: Number of fields that row actually has.
+    """
+    path = _write(tmp_path / "ragged.tsv", f"A\tB\tC\n{row}\n7\t8\t9\n")
+
+    with caplog.at_level(logging.WARNING):
+        result = parse_tsv(path)
+
+    # The malformed row is gone; the good row after it survives.
+    assert result["data"] == [{"A": "7", "B": "8", "C": "9"}]
+    assert f"expected 3 fields, found {found}" in caplog.text
+    assert "ragged.tsv:2" in caplog.text
+
+
+def test_parse_csv_skips_ragged_row_and_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """The CSV parser applies the same rule as the TSV parser."""
+    path = _write(tmp_path / "ragged.csv", "A,B,C\n1,2\n7,8,9\n")
+
+    with caplog.at_level(logging.WARNING):
+        result = parse_csv(path)
+
+    assert result["data"] == [{"A": "7", "B": "8", "C": "9"}]
+    assert "expected 3 fields, found 2" in caplog.text
+
+
+def test_one_bad_row_does_not_discard_the_file(tmp_path: Path) -> None:
+    """A single malformed line must not cost every other row in the file.
+
+    This is why the field count is checked per row instead of relying on
+    zip(strict=True), whose ValueError would escape to the module's broad handler.
+    """
+    lines = "\n".join(f"{i}\t{i}\t{i}" for i in range(20))
+    path = _write(tmp_path / "mostly-good.tsv", f"A\tB\tC\n{lines}\nBROKEN\n")
+
+    result = parse_tsv(path)
+
+    assert len(result["data"]) == 20
+    assert not any("Error parsing" in comment for comment in result["comments"])
+
+
+# --- error handling ----------------------------------------------------------
+
+
+def test_parse_tsv_reports_unreadable_file(tmp_path: Path) -> None:
+    """An unreadable file is reported as a comment, not raised."""
+    result = parse_tsv(str(tmp_path / "does-not-exist.tsv"))
+
+    assert result["data"] == []
+    assert any("Error parsing TSV file" in comment for comment in result["comments"])
+
+
+def test_parse_csv_reports_unreadable_file(tmp_path: Path) -> None:
+    """The CSV parser degrades the same way."""
+    result = parse_csv(str(tmp_path / "does-not-exist.csv"))
+
+    assert result["data"] == []
+    assert any("Error parsing CSV file" in comment for comment in result["comments"])
+
+
+def test_header_only_file_yields_no_rows(tmp_path: Path) -> None:
+    """A file with only a header is valid and contributes no data."""
+    assert parse_tsv(_write(tmp_path / "hdr.tsv", "A\tB\n"))["data"] == []

--- a/tests/unit/test_version_consistency.py
+++ b/tests/unit/test_version_consistency.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+tests/unit/test_version_consistency.py
+
+Keeps the PyPI package and the Docker image in agreement about versions.
+
+The supported interpreter is asserted in six places, in four different file formats:
+
+    conda/environment_vntyper.yml            python=X.Y.Z   (what the image RUNS)
+    pyproject.toml  [project]                requires-python = ">=X.Y"
+    pyproject.toml  [project] classifiers    Programming Language :: Python :: X.Y
+    pyproject.toml  [tool.ruff]              target-version = "pyXY"
+    pyproject.toml  [tool.mypy]              python_version = "X.Y"
+    .github/workflows/ci-tests.yml           matrix python-version: [...]
+    tests/docker/test_image_structure.py     expected interpreter in the image
+
+Nothing makes them agree on its own, and disagreement is silent and expensive: shipping
+an interpreter the test matrix never exercises, or letting ruff accept syntax the
+declared floor cannot run. This test is the mechanism that keeps them in sync.
+
+Deliberately dependency-free (no tomllib - the 3.10 matrix leg has none, and tomli is
+not a dependency) and pure file reads, so it belongs in the fast unit tier.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CONDA_ENV = REPO_ROOT / "conda" / "environment_vntyper.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci-tests.yml"
+SMOKE_TEST = REPO_ROOT / "tests" / "docker" / "test_image_structure.py"
+
+
+def _read(path: Path) -> str:
+    """Return a file's text, skipping the test if it is absent.
+
+    Args:
+        path: File to read.
+
+    Returns:
+        str: File contents.
+    """
+    if not path.is_file():
+        pytest.skip(f"{path.relative_to(REPO_ROOT)} not present in this tree")
+    return path.read_text(encoding="utf-8")
+
+
+def _search(pattern: str, text: str, what: str) -> re.Match[str]:
+    """Search for a required pattern, failing with a useful message if absent.
+
+    Args:
+        pattern: Regular expression.
+        text: Text to search.
+        what: Human-readable description used in the failure message.
+
+    Returns:
+        re.Match: The match object.
+    """
+    match = re.search(pattern, text, re.MULTILINE)
+    assert match, f"could not find {what} - has the file format changed?"
+    return match
+
+
+def conda_python() -> tuple[int, int]:
+    """Return the (major, minor) Python pinned in the vntyper conda environment.
+
+    Returns:
+        tuple: Major and minor version.
+    """
+    match = _search(r"^\s*-\s*python=(\d+)\.(\d+)", _read(CONDA_ENV), "the conda python pin")
+    return int(match.group(1)), int(match.group(2))
+
+
+def requires_python_floor() -> tuple[int, int]:
+    """Return the (major, minor) floor declared by ``requires-python``.
+
+    Returns:
+        tuple: Major and minor version.
+    """
+    match = _search(r'^requires-python\s*=\s*">=(\d+)\.(\d+)"', _read(PYPROJECT), "requires-python")
+    return int(match.group(1)), int(match.group(2))
+
+
+def classifier_versions() -> set[tuple[int, int]]:
+    """Return the Python versions listed in the trove classifiers.
+
+    Returns:
+        set: (major, minor) pairs.
+    """
+    text = _read(PYPROJECT)
+    return {
+        (int(major), int(minor))
+        for major, minor in re.findall(r'"Programming Language :: Python :: (\d+)\.(\d+)"', text)
+    }
+
+
+def matrix_versions() -> set[tuple[int, int]]:
+    """Return the Python versions in the CI unit-test matrix.
+
+    Returns:
+        set: (major, minor) pairs.
+    """
+    match = _search(r"^\s*python-version:\s*\[(.+)\]", _read(CI_WORKFLOW), "the CI python matrix")
+    return {(int(major), int(minor)) for major, minor in re.findall(r"'(\d+)\.(\d+)'", match.group(1))}
+
+
+def test_conda_python_satisfies_requires_python() -> None:
+    """The interpreter the image ships must satisfy the package's declared floor."""
+    assert conda_python() >= requires_python_floor(), (
+        f"conda env ships Python {conda_python()} but requires-python declares >={requires_python_floor()}"
+    )
+
+
+def test_ci_matrix_covers_the_shipped_interpreter() -> None:
+    """CI must test the interpreter version the Docker image actually runs.
+
+    Otherwise the version users run is the one version nothing exercises.
+    """
+    assert conda_python() in matrix_versions(), (
+        f"the image runs Python {conda_python()}, which is not in the CI matrix {sorted(matrix_versions())}"
+    )
+
+
+def test_matrix_lowest_equals_requires_python_floor() -> None:
+    """The matrix must actually exercise the oldest version the package claims."""
+    assert min(matrix_versions()) == requires_python_floor(), (
+        f"requires-python declares >={requires_python_floor()} but the lowest tested "
+        f"version is {min(matrix_versions())}"
+    )
+
+
+def test_classifiers_match_the_matrix() -> None:
+    """Trove classifiers must advertise exactly the versions CI tests."""
+    assert classifier_versions() == matrix_versions(), (
+        f"classifiers {sorted(classifier_versions())} != CI matrix {sorted(matrix_versions())}"
+    )
+
+
+def test_ruff_target_matches_requires_python() -> None:
+    """Ruff must reject syntax newer than the declared floor can run."""
+    major, minor = requires_python_floor()
+    match = _search(r'^target-version\s*=\s*"py(\d+)"', _read(PYPROJECT), "ruff target-version")
+    assert match.group(1) == f"{major}{minor}", (
+        f'ruff target-version is "py{match.group(1)}" but requires-python is >={major}.{minor}'
+    )
+
+
+def test_mypy_python_version_matches_requires_python() -> None:
+    """mypy must type-check against the declared floor."""
+    major, minor = requires_python_floor()
+    match = _search(r'^python_version\s*=\s*"(\d+)\.(\d+)"', _read(PYPROJECT), "mypy python_version")
+    assert (int(match.group(1)), int(match.group(2))) == (major, minor), (
+        f"mypy targets {match.group(0)} but requires-python is >={major}.{minor}"
+    )
+
+
+def test_smoke_test_expects_the_shipped_interpreter() -> None:
+    """The image smoke tier must assert the version the conda environment installs."""
+    major, minor = conda_python()
+    match = _search(r'\("vntyper",\s*"(\d+\.\d+)"\)', _read(SMOKE_TEST), "the smoke test's expected version")
+    assert match.group(1) == f"{major}.{minor}", (
+        f"the image smoke test expects Python {match.group(1)} but the conda env pins {major}.{minor}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Package dependencies vs the conda environment the Docker image installs
+# ---------------------------------------------------------------------------
+# The most consequential drift this guards: pyproject pinned numpy>=1.26.0,<2.0.0 while
+# the conda environment installed numpy=2.0.2, so `pip install .` inside the image
+# downgraded conda's numpy and the published image silently ran 1.26.4 - a different
+# numerical stack from the one the environment file declares.
+
+
+def _normalise(name: str) -> str:
+    """Normalise a distribution name for comparison across PyPI and conda.
+
+    Args:
+        name: Raw package name.
+
+    Returns:
+        str: Lower-cased name with underscores folded to hyphens.
+    """
+    return name.strip().lower().replace("_", "-")
+
+
+def pyproject_dependencies() -> dict[str, str]:
+    """Return the runtime dependencies declared in ``[project] dependencies``.
+
+    Returns:
+        dict: Normalised package name -> PEP 440 specifier (may be empty).
+    """
+    text = _read(PYPROJECT)
+    # DOTALL: the array spans lines. The `^dependencies` anchor keeps this to
+    # [project] dependencies and away from [project.optional-dependencies].
+    match = re.search(r"^dependencies = \[(.*?)^\]", text, re.MULTILINE | re.DOTALL)
+    assert match, "could not find [project] dependencies - has the file format changed?"
+    block = match.group(1)
+    found: dict[str, str] = {}
+    for raw in re.findall(r'"([^"]+)"', block):
+        match = re.match(r"^([A-Za-z0-9._-]+)\s*(.*)$", raw.strip())
+        if match:
+            found[_normalise(match.group(1))] = match.group(2).strip()
+    return found
+
+
+def conda_dependencies() -> dict[str, str]:
+    """Return the pinned packages in the vntyper conda environment.
+
+    Returns:
+        dict: Normalised package name -> exact pinned version.
+    """
+    found: dict[str, str] = {}
+    for line in _read(CONDA_ENV).splitlines():
+        # e.g. "  - bioconda::fastp=0.23.4" or "  - pandas=2.2.2"
+        match = re.match(r"^\s*-\s*(?:[A-Za-z0-9_-]+::)?([A-Za-z0-9._-]+)=([\w.]+)\s*$", line)
+        if match:
+            found[_normalise(match.group(1))] = match.group(2)
+    return found
+
+
+def test_conda_versions_satisfy_pyproject_specifiers() -> None:
+    """Every shared dependency's conda pin must satisfy the package's own specifier.
+
+    When it does not, `pip install .` inside the image resolves a *different* version
+    than the environment declares, and the shipped image stops matching the recipe.
+    """
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+
+    declared = pyproject_dependencies()
+    pinned = conda_dependencies()
+    shared = sorted(set(declared) & set(pinned))
+    assert shared, "no shared dependencies found - have the file formats changed?"
+
+    conflicts = []
+    for name in shared:
+        specifier = declared[name]
+        if not specifier:
+            continue
+        if Version(pinned[name]) not in SpecifierSet(specifier):
+            conflicts.append(f"{name}: conda pins {pinned[name]}, pyproject requires {specifier}")
+
+    assert not conflicts, (
+        "the conda environment installs versions the package forbids, so pip would "
+        "replace them inside the image:\n  " + "\n  ".join(conflicts)
+    )
+
+
+def test_image_required_binaries_are_in_the_conda_environment() -> None:
+    """Every binary the image smoke tier requires must be declared in the environment.
+
+    Catches a tool being dropped from the recipe before a 25-minute base build proves
+    it at runtime.
+    """
+    required = re.findall(
+        r'"([a-z0-9-]+)"', _search(r"^REQUIRED_BINARIES = \((.*?)\)", _read(SMOKE_TEST), "REQUIRED_BINARIES").group(1)
+    )
+    assert required, "could not parse REQUIRED_BINARIES from the smoke test"
+
+    pinned = conda_dependencies()
+    # `java` is provided by openjdk rather than a package of its own.
+    provided = set(pinned) | ({"java"} if "openjdk" in pinned else set())
+    missing = [tool for tool in required if _normalise(tool) not in provided]
+    assert not missing, f"the image smoke tier requires {missing}, which the conda environment does not declare"

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+tests/unit/test_workflow_consistency.py
+
+Guards invariants that span more than one GitHub Actions workflow file.
+
+The base Docker image is content-addressed: docker-base.yml tags it with a hash of its
+build inputs, and docker-build.yml recomputes the same hash to decide whether that base
+exists and to pin the application build to it. Three separate `hashFiles(...)` calls
+must therefore agree exactly. If one drifts, the tag silently changes meaning: the app
+either rebuilds a base that already exists, or - worse - resolves a base built from
+different inputs.
+
+YAML has no way to share the expression, so it is duplicated by necessity. This test is
+what stops the duplication from rotting. It is a plain unit test: it only reads files,
+needs no Docker and no network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+# Matches the base-image hash expression specifically (it always starts with conda/**),
+# not the unrelated test-data cache key that also uses hashFiles().
+_BASE_HASH = re.compile(r"hashFiles\((\s*'conda/\*\*'.*?)\)", re.DOTALL)
+
+
+def _base_hash_expressions() -> dict[str, list[str]]:
+    """Collect every base-image hashFiles() argument list, keyed by file name.
+
+    Returns:
+        dict: Workflow file name -> list of normalised argument strings.
+    """
+    found: dict[str, list[str]] = {}
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        matches = _BASE_HASH.findall(path.read_text(encoding="utf-8"))
+        if matches:
+            found[path.name] = [" ".join(match.split()) for match in matches]
+    return found
+
+
+def test_base_image_hash_inputs_are_identical() -> None:
+    """Every base-image hashFiles() call must list exactly the same paths.
+
+    Raises:
+        AssertionError: If the workflows disagree on the base image's inputs.
+    """
+    found = _base_hash_expressions()
+    assert found, "no base-image hashFiles() expressions found - did the workflows move?"
+
+    distinct = {expression for expressions in found.values() for expression in expressions}
+    assert len(distinct) == 1, (
+        "workflows disagree on the base image's hash inputs, so the content-addressed "
+        f"tag means different things in different jobs:\n{found}"
+    )
+
+
+def test_base_hash_covers_everything_that_changes_the_base() -> None:
+    """The hash must cover every input that can change the base image's contents.
+
+    `.dockerignore` and `reference/**` are easy to forget and were genuinely missed:
+    excluding all of reference/ dropped three config-declared files from the image
+    without changing the tag, so no rebuild was triggered.
+
+    Raises:
+        AssertionError: If a required path is absent from the hash inputs.
+    """
+    required = (
+        "conda/**",
+        "docker/Dockerfile.base",
+        "docker/requirements-web.txt",
+        "vntyper/scripts/install_references.py",
+        "vntyper/scripts/install_references_config.json",
+        "vntyper/dependencies/advntr/**",
+        "reference/**",
+        ".dockerignore",
+    )
+    expressions = _base_hash_expressions()
+    assert expressions, "no base-image hashFiles() expressions found"
+    sample = next(iter(expressions.values()))[0]
+
+    missing = [path for path in required if f"'{path}'" not in sample]
+    assert not missing, f"base image hash does not cover: {missing}"

--- a/tests/unit/test_workflow_consistency.py
+++ b/tests/unit/test_workflow_consistency.py
@@ -53,7 +53,10 @@ def test_base_image_hash_inputs_are_identical() -> None:
         AssertionError: If the workflows disagree on the base image's inputs.
     """
     found = _base_hash_expressions()
-    assert found, "no base-image hashFiles() expressions found - did the workflows move?"
+    if not found:
+        # No .github/workflows/ here: a source checkout without it, or an installed
+        # sdist. Nothing to guard, so skip rather than fail on an absent directory.
+        pytest.skip("no GitHub Actions workflows present in this tree")
 
     distinct = {expression for expressions in found.values() for expression in expressions}
     assert len(distinct) == 1, (
@@ -83,7 +86,8 @@ def test_base_hash_covers_everything_that_changes_the_base() -> None:
         ".dockerignore",
     )
     expressions = _base_hash_expressions()
-    assert expressions, "no base-image hashFiles() expressions found"
+    if not expressions:
+        pytest.skip("no GitHub Actions workflows present in this tree")
     sample = next(iter(expressions.values()))[0]
 
     missing = [path for path in required if f"'{path}'" not in sample]

--- a/vntyper/scripts/summary.py
+++ b/vntyper/scripts/summary.py
@@ -16,7 +16,10 @@ so that all available data is expanded into individual columns.
 import csv
 import hashlib
 import json
+import logging
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 
 
 def start_summary(version=None, input_files=None):
@@ -85,8 +88,8 @@ def parse_tsv(file_path):
 
     try:
         with open(file_path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
+            for line_number, raw_line in enumerate(f, start=1):
+                line = raw_line.strip()
                 if not line:
                     continue
                 if line.startswith("#"):
@@ -96,12 +99,19 @@ def parse_tsv(file_path):
                     header = line.split("\t")
                     continue
                 row_values = line.split("\t")
-                # strict=False preserves the long-standing behaviour: a ragged row is
-                # truncated to the shorter of the two rather than raising. strict=True
-                # would escape to the except below and discard the whole file's data
-                # because of one malformed line.
-                row_dict = dict(zip(header, row_values, strict=False))
-                data.append(row_dict)
+                # Validate the field count per row rather than letting zip() silently
+                # truncate to the shorter sequence: a ragged row means a malformed or
+                # truncated file, and dropping columns without a word turns corruption
+                # into a plausible-looking result. Skipping just the bad row keeps one
+                # bad line from discarding the whole file, which is what strict=True
+                # would do here (the exception would escape to the handler below).
+                if len(row_values) != len(header):
+                    logger.warning(
+                        f"{file_path}:{line_number}: skipping malformed row - expected "
+                        f"{len(header)} fields, found {len(row_values)}"
+                    )
+                    continue
+                data.append(dict(zip(header, row_values, strict=True)))
     except Exception as e:
         comments.append(f"Error parsing TSV file: {e}")
 
@@ -136,10 +146,15 @@ def parse_csv(file_path):
                 if header is None:
                     header = row
                     continue
-                # See the note in parse_tsv_file: strict=False keeps a single ragged
-                # row from discarding the entire parse.
-                row_dict = dict(zip(header, row, strict=False))
-                data.append(row_dict)
+                # See the note in parse_tsv: warn and skip the individual malformed row
+                # rather than silently truncating it or discarding the whole file.
+                if len(row) != len(header):
+                    logger.warning(
+                        f"{file_path}:{reader.line_num}: skipping malformed row - expected "
+                        f"{len(header)} fields, found {len(row)}"
+                    )
+                    continue
+                data.append(dict(zip(header, row, strict=True)))
     except Exception as e:
         comments.append(f"Error parsing CSV file: {e}")
 

--- a/vntyper/scripts/summary.py
+++ b/vntyper/scripts/summary.py
@@ -96,7 +96,11 @@ def parse_tsv(file_path):
                     header = line.split("\t")
                     continue
                 row_values = line.split("\t")
-                row_dict = dict(zip(header, row_values))
+                # strict=False preserves the long-standing behaviour: a ragged row is
+                # truncated to the shorter of the two rather than raising. strict=True
+                # would escape to the except below and discard the whole file's data
+                # because of one malformed line.
+                row_dict = dict(zip(header, row_values, strict=False))
                 data.append(row_dict)
     except Exception as e:
         comments.append(f"Error parsing TSV file: {e}")
@@ -132,7 +136,9 @@ def parse_csv(file_path):
                 if header is None:
                     header = row
                     continue
-                row_dict = dict(zip(header, row))
+                # See the note in parse_tsv_file: strict=False keeps a single ragged
+                # row from discarding the entire parse.
+                row_dict = dict(zip(header, row, strict=False))
                 data.append(row_dict)
     except Exception as e:
         comments.append(f"Error parsing CSV file: {e}")

--- a/vntyper/version.py
+++ b/vntyper/version.py
@@ -1,3 +1,3 @@
 # vntyper/version.py
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"


### PR DESCRIPTION
Cuts the Docker pipeline's critical path from a measured **53 min to ~3 min per commit**, and fixes several correctness bugs found along the way — including one that meant **PR builds never tested PR code**.

All numbers below are measured, not estimated.

## Measured baseline

From run `31023249248` (a real, green run on `main`):

| Job | Duration |
| --- | --- |
| `build-and-push-image` | 30.5 min |
| `Docker Tests (Quick)` | 22.7 min |
| **Critical path** | **53.3 min** |

Setup steps accounted for 14 seconds. Per-layer breakdown of the build:

| Layer | Time | Share |
| --- | --- | --- |
| **exporting to GitHub Actions Cache** | **14.0 min** | **46%** |
| `install-references` | 5.9 min | 19% |
| exporting to image (push) | 3.2 min | 10% |
| everything else | ~7 min | 25% |

## Four independent problems

**1. The image was built 2–3× per run.** `tests/docker/conftest.py` ran a plain uncached `docker build` inside a pytest fixture, ignoring the image the previous job had just built and pushed — so `needs:` was pure serialization. Measured: **1042.65s of fixture setup to run 16.97s of assertions.**

**2. 14 min/build wrote a cache nothing could read.** GitHub scopes a PR's cache to `refs/pull/N/merge`, readable only by that PR, and the workflow added a *second* per-branch partition on top. Proof: the `git clone` layer ran for 95s instead of reporting `CACHED`. Repo cache usage was **11.62 GB against a 10 GB limit**, 8.59 GB of it stranded on two closed PRs — evicting everything else, including the only test-data entry, which is why `main` re-downloaded 1.1 GB every run.

**3. `docker-build.yml` had no `concurrency` group**, so overlapping pushes each ran a full cold build (2 collisions in 11 sampled runs).

**4. Quick and full Docker tiers were serialized and redundant.** Every "quick" test carries `@pytest.mark.docker`, so the full suite re-ran all of them — ~13 min of critical path for no new information.

## Correctness bugs fixed

- **The build never tested your code.** `RUN git clone` fetched GitHub `main`, so PR builds validated `main`, not the PR. And since the command string never changed, a cache hit could serve an arbitrarily stale checkout.
- **`docker/app` edits were silently discarded.** The final stage re-copied `docker/app` from the cloned tree over the context copy, so the git version won and files deleted upstream survived as zombies.
- **The digest pin did nothing.** `conda install -y mamba` was a no-op (miniforge3 already ships mamba 1.5.12) that floated conda to 26.7.0 and mamba to 2.8.1 at build time.
- **Corrupted test-data cache was unrecoverable.** The verify step deleted the cache and `exit 0`ed, but the re-download was gated on `cache-hit != 'true'` — false on that path. The comment said "Will re-download"; it did not.
- **Images were pushed before being tested.** Now they publish only after their tests pass.
- **Fork PRs could never pass** — `push: true` with a read-only `GITHUB_TOKEN`. PRs no longer push.
- `ci-tests.yml` triggered on `develop` and `docker-modernization-2025`; `git ls-remote` shows only `main`.

## Architecture

The image is split in two, bound by a content hash of the base's inputs:

| | Contents | Rebuilt |
| --- | --- | --- |
| `docker/Dockerfile.base` | conda envs, adVNTR, FastAPI stack, reference genomes + BWA indexes | only when those inputs change |
| `docker/Dockerfile` | the application | every commit |

`docker-build.yml` recomputes the same hash; if no base exists for it, a `build-base` job builds one on demand — so the first run and any PR changing `conda/**` work rather than dead-ending.

Layer cache moved from `type=gha` (beta, 10 GB cap, hourly LRU eviction) to `type=registry` on ghcr, which is free and uncapped for public repos, with a `buildcache-main` fallback so new branches start warm. All five BuildKit cache mounts were removed — BuildKit never exports them to a remote backend, so they were dead weight in CI, and one at `/opt/conda/pkgs` also blocked conda hardlinking (~330 MB).

## Results

| Metric | Before | After |
| --- | --- | --- |
| Per-commit image build | 27–30 min | **6s local** / ~2–3 min CI |
| Docker test fixture setup | 1042.65s | **5.18s** |
| Image size | 7.01 GB published | **4.78 GB** |
| Build context | 49 MB | **3.19 MB** |
| Unit tests | 278 | **311** |
| `make check-all` | unrunnable | **~4s** |

## Test-driven development

The pre-PR gate `make check-all` depended on bare `pytest` — the full suite including the tier needing 1.1 GB of Zenodo data and the tier needing a Docker daemon. On a fresh clone it either downloaded 1.1 GB or died in `pytest.exit()`. **The one command contributors were told to run could not be run.** It now gates on the unit tier and completes in ~4s.

- **30 dead tests recovered.** `test_haplo_count_and_selection.py` had no `pytestmark`, so its 30 tests covering the Issue #136/#145 genotype tie-breaking logic were collected, deselected, and never run. All pass; `kestrel_genotyping.py` coverage 17% → 28%.
- **Two guard tests** make that class of bug unrepeatable: marker hygiene, and base-image hash consistency across workflows. Both verified to fail when the defect is reintroduced.
- **Coverage gate**: a hard floor that CI fails below and only ratchets up, plus an **80% target** that warns with the remaining gap. Currently 25%.
- **New 1s image smoke tier** (28 assertions, no test data): asserts every reference path `config.json` declares actually resolves in the image — *derived from the config inside the container*, so it cannot drift from it.
- `pytest-timeout` was a pinned dependency "to prevent stuck tests" with its config commented out; now enabled at 600s.
- `--dist loadfile` → `--dist load`: all 11 integration tests live in one file, so `loadfile` gave them all to one worker.

## Local CI parity

`make ci-local` mirrors `ci-tests.yml` job for job (3s); `make ci-local-docker` mirrors the image side. Both **fail rather than skip** when a tool is missing, and state what they could not verify locally.

## Verification

- Unit: **311 passed**; smoke: **28 passed**; Docker quick: **4 passed / 13.45s**; Docker full: **13 passed / 7:11**
- Pipeline run end-to-end in the new image reproduces the expected genotype for `example_b178_hg19_subset`: `Estimated_Depth_AlternateVariant` **416** (expected 416), active-region depth 7088 (expected 7110 ±5%)
- All 7 config reference paths + SHARK's `muc1_region_hg19.fa` resolve in the image
- `actionlint` clean on all 5 workflows; `docker build --check` clean on both Dockerfiles
- `make check-all`, `make ci-local`, `make ci-local-docker` all pass

## Needs a decision

- **Trusted Publishing** for PyPI is documented in `publish-pypi.yml` but deliberately **not switched on** — it needs matching PyPI-side config first, and flipping the workflow without it breaks the next release.
- **Python 3.9 is EOL** (2025-10-31) and has no build for `ubuntu-26.04`. Runners are pinned to `ubuntu-24.04` so this keeps working, but dropping 3.9 is a support-policy call.
- **`pyproject.toml` pins `numpy<2.0.0` while `conda/environment_vntyper.yml` installs `numpy=2.0.2`.** The Dockerfile uses `pip install --no-deps` to stop pip clobbering conda's copy; the two should be reconciled.

## Deliberately out of scope

The test-data design (all-or-nothing 1.1 GB re-download when one file is missing; `pytest.exit()` killing the whole session including unit tests). Changing `pytest.exit()` to `skip` would also silence genuine CI cache failures, so it needs its own change rather than being bundled into a CI-performance PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW3Z5Gx2MBSzGzp38QMFKa

## Summary by Sourcery

Split the Docker image into a reusable base and a fast per-commit application image, overhaul CI workflows for correctness and speed, and introduce coverage and workflow guards to keep builds reliable and fast.

New Features:
- Introduce a separate Docker base image workflow that builds and publishes a content-addressed base with conda environments, adVNTR, and reference data.
- Add fast image smoke tests and an image probe to validate Docker image structure and references without requiring test data.
- Provide local CI parity commands (ci-local, ci-local-docker, ci-local-docs) to mirror GitHub workflows on developer machines.
- Add a coverage gate script and configuration to enforce a ratcheting unit-test coverage floor with a higher soft target.
- Introduce workflow consistency and marker hygiene unit tests to guard cross-workflow invariants and ensure unit tests are properly marked.

Bug Fixes:
- Ensure Docker builds test the PR’s application code from the build context instead of cloning GitHub main and risking stale caches.
- Prevent Docker test fixtures from rebuilding images unnecessarily by honoring a VNTYPER_TEST_IMAGE override and reusing built images.
- Fix test-data cache corruption handling so invalid caches are cleared and re-downloaded, and restrict cache writes to main to avoid evicting reusable entries.
- Ensure images are only pushed after tests pass and avoid pushing from forked pull requests that lack registry permissions.
- Prevent CI from leaving required checks pending by replacing workflow-level path filters with per-job change detection and a single success gate job.
- Align PyPI publishing with the tagged version by verifying tags against vntyper/version.py before uploading.

Enhancements:
- Refactor docker-build workflow to build and test in a single job, use registry-backed build caches, and pin bases by content hash.
- Convert Dockerfile to layer on a prebuilt base image, simplify application installation, and avoid redundant reference installation work.
- Optimize CI tests workflow with path-based job gating, uv-based dependency installs, pinned runners, and a docs build job that runs on PRs.
- Reorganize Makefile targets to add fast test and coverage gates, new CI parity targets, and clearer Docker build/smoke flows.
- Tighten pytest configuration with timeouts, stricter marker handling, and lower duration thresholds to surface slow tests earlier.
- Harden docs and PyPI workflows with least-privilege permissions, uv usage, fixed runners, and resilience to partial failures.

Tests:
- Add image structure smoke tests and an in-container probe to assert key binaries, environments, references, and size budgets for Docker images.
- Add unit tests to enforce consistency of base-image hash inputs across workflows and to ensure all unit test files are properly marked and selected.
- Recover previously unrun haplotype selection tests by marking them as unit tests and integrating them into the unit suite.
- Extend AGENTS and Docker testing documentation with guidance on new gates, smoke tests, and image split architecture.

---

## Update: Python 3.12 and version-sync guards

Added after the initial review, at the maintainer's request.

**The image shipped Python 3.9.19**, EOL since 2025-10-31. `conda/environment_vntyper.yml`
now pins 3.12.13; the package declares `requires-python >=3.10` and is tested on
3.10–3.13.

Reproducibility was the deciding factor: **every package on the numerical path resolves
to the same version** under 3.12 — bwa 0.7.18, samtools 1.20, fastp 0.23.4, bcftools
1.21, openjdk 11.0.23 (Kestrel), pysam 0.22.1, numpy 2.0.2, pandas 2.2.2, biopython
1.84. Only the reporting stack moved. Verified end to end: the pipeline reproduces the
expected genotype for `example_b178_hg19_subset` exactly — alternate depth **416**
(expected 416), active-region depth **7088** (expected 7110 ±5%), `High_Precision*`.

**A real inconsistency this exposed:** `pyproject.toml` pinned `numpy>=1.26.0,<2.0.0`
while the conda environment installed `numpy=2.0.2`, so `pip install .` inside the image
downgraded conda's numpy — the published image ran **1.26.4** on a different numerical
stack than its own recipe declared.

`tests/unit/test_version_consistency.py` prevents recurrence. Each check was verified to
fire by reintroducing the drift:

```
numpy: conda pins 2.0.2, pyproject requires >=1.26.0,<2.0.0
the image smoke test expects Python 3.12 but the conda env pins 3.11
the image smoke tier requires ['bcftools'], which the conda environment does not declare
```

It ties together `requires-python` ↔ classifiers ↔ CI matrix ↔ ruff `target-version` ↔
mypy `python_version` ↔ the image's interpreter ↔ every shared dependency pin.

**Other fixes in this round**

- TSV/CSV summary parsers silently truncated rows whose field count disagreed with the
  header, producing records that looked valid but were missing columns — and these feed
  the report. Now logged and skipped per row, without discarding the rest of the file.
  `summary.py` also had no module logger; coverage 12% → 49%.
- All eleven actions updated to their Node 24 majors (Node 20 is deprecated).
  `astral-sh/setup-uv` is pinned to `v9.0.0` — it is the only one publishing no moving
  major tag.
- `docker-build.yml` no longer cancels superseded PR runs: a push was discarding
  in-flight 25-minute base builds. Gating cancellation on "is a base being built" is not
  expressible — `concurrency` is evaluated before any job and cannot read `needs` — and
  the trade has inverted anyway now that the per-commit build is ~3 min.

**Review findings addressed:** all four valid Sourcery items, and four of five from an
independent Codex review — including one that let an unmerged PR overwrite the
production `:latest` base tag. The fifth (that `.dockerignore`'s `*.zip` excluded the
adVNTR database) was verified incorrect: Docker's `filepath.Match` means `*` does not
cross `/`, and the zip is demonstrably in the build context.
